### PR TITLE
Support for optional, external configuration file

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfig.java
@@ -44,6 +44,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	public DaoConfig daoConfig() {
 		DaoConfig retVal = new DaoConfig();
 		retVal.setAllowMultipleDelete(HapiProperties.getAllowMultipleDelete());
+                retVal.setFetchSizeDefaultMaximum(HapiProperties.getMaximumFetchSize());
 		retVal.setAllowExternalReferences(HapiProperties.getAllowExternalReferences());
 		retVal.setExpungeEnabled(HapiProperties.getExpungeEnabled());
 
@@ -90,6 +91,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 		retVal.setUrl(HapiProperties.getDataSourceUrl());
 		retVal.setUsername(HapiProperties.getDataSourceUsername());
 		retVal.setPassword(HapiProperties.getDataSourcePassword());
+    retVal.setMaxTotal(HapiProperties.getDataSourceMaxPoolSize());
 		return retVal;
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
@@ -48,6 +48,10 @@ public class FhirServerConfigCommon {
 		Boolean allowPlaceholderReferences = HapiProperties.getAllowPlaceholderReferences();
 		retVal.setAutoCreatePlaceholderReferenceTargets(allowPlaceholderReferences);
 		ourLog.info("Server configured to " + (allowPlaceholderReferences ? "allow" : "deny") + " placeholder references");
+
+		Integer maxFetchSize = HapiProperties.getMaximumFetchSize();
+		retVal.setFetchSizeDefaultMaximum(maxFetchSize);
+		ourLog.info("Server configured to have a maximum fetch size of " + (maxFetchSize == Integer.MAX_VALUE? "'unlimited'": maxFetchSize));
 		
 		// You can enable these if you want to support Subscriptions from your server
 		if (HapiProperties.getSubscriptionRestHookEnabled()) {
@@ -82,7 +86,7 @@ public class FhirServerConfigCommon {
 		retVal.setUrl(HapiProperties.getDataSourceUrl());
 		retVal.setUsername(HapiProperties.getDataSourceUsername());
 		retVal.setPassword(HapiProperties.getDataSourcePassword());
-    retVal.setMaxTotal(HapiProperties.getDataSourceMaxPoolSize());
+		retVal.setMaxTotal(HapiProperties.getDataSourceMaxPoolSize());
 		return retVal;
 	}
 


### PR DESCRIPTION
Allow optional, external configurations to override the entries in hapi.properties.

Such configurations can be specified in a properties file outside of the war (or
webapps/hapi-fhir-jpaserver) and the server may be instructed to load the configuration using
  -Dhapi.properties=<path-of-external-configuration-file>
This is helpful in at least two use cases:
1. Deploying multiple instances with different configurations (e.g., different databases)
2. Future upgrade - just update the war without the need to change hapi.properties after update.