### PR TITLE
Add cache timeout configuration property. Disabled by default

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
@@ -89,6 +89,10 @@ public class FhirServerConfigCommon {
 		Integer maxFetchSize = HapiProperties.getMaximumFetchSize();
 		retVal.setFetchSizeDefaultMaximum(maxFetchSize);
 		ourLog.info("Server configured to have a maximum fetch size of " + (maxFetchSize == Integer.MAX_VALUE? "'unlimited'": maxFetchSize));
+
+		Long reuseCachedSearchResultsMillis = HapiProperties.getReuseCachedSearchResultsMillis();
+		retVal.setReuseCachedSearchResultsForMillis(reuseCachedSearchResultsMillis );
+		ourLog.info("Server configured to cache search results for {} milliseconds", reuseCachedSearchResultsMillis);
 		
 		// Subscriptions are enabled by channel type
 		if (HapiProperties.getSubscriptionRestHookEnabled()) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -14,6 +14,7 @@ public class HapiProperties {
     static final String ALLOW_EXTERNAL_REFERENCES = "allow_external_references";
     static final String ALLOW_MULTIPLE_DELETE = "allow_multiple_delete";
     static final String ALLOW_PLACEHOLDER_REFERENCES = "allow_placeholder_references";
+    static final String REUSE_CACHED_SEARCH_RESULTS_MILLIS = "reuse_cached_search_results_millis";
     static final String DATASOURCE_DRIVER = "datasource.driver";
     static final String DATASOURCE_MAX_POOL_SIZE = "datasource.max_pool_size";
     static final String DATASOURCE_PASSWORD = "datasource.password";
@@ -311,5 +312,10 @@ public class HapiProperties {
 
     public static String getEmailPassword() {
         return HapiProperties.getProperty("email.password");
+    }
+
+    public static Long getReuseCachedSearchResultsMillis() {
+        String value = HapiProperties.getProperty(REUSE_CACHED_SEARCH_RESULTS_MILLIS, "-1");
+        return Long.valueOf(value);
     }
 }

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -20,6 +20,7 @@ server.base=/fhir
 
 default_encoding=JSON
 etag_support=ENABLED
+reuse_cached_search_results_millis=-1
 default_page_size=20
 max_page_size=200
 allow_override_default_search_params=true


### PR DESCRIPTION
Adds cache timeout configuration property.

This is useful when using hapi-fhir-jpaserver-starter as a test FHIR server which relies on returned results not being stale.

I disabled caching by default.

Thanks!