### PR TITLE
Pom mail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,11 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>6.0.5</version>
         </dependency>
-		<dependency>
-			<groupId>javax.mail</groupId>
-			<artifactId>javax.mail-api</artifactId>
-			<version>1.5.2</version>
-		</dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
+            <version>1.5.2</version>
+        </dependency>
 
         <!-- This dependency includes the core HAPI-FHIR classes -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>6.0.5</version>
         </dependency>
+		<dependency>
+			<groupId>javax.mail</groupId>
+			<artifactId>javax.mail-api</artifactId>
+			<version>1.5.2</version>
+		</dependency>
 
         <!-- This dependency includes the core HAPI-FHIR classes -->
         <dependency>


### PR DESCRIPTION
Adding javax.mail dependency to pom.xml so that when properties are configured to enable mail, the pom.xml doesn't have to be additionally modified for it to work.
