### PR TITLE
Reverting recent change to increment hapi-fhir parent to 3.8.0. Now r…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>3.8.0-SNAPSHOT</version>
+        <version>3.7.0-SNAPSHOT</version>
     </parent>
 
     <groupId>ca.uhn.hapi.fhir.demo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.7.0</version>
     </parent>
 
     <groupId>ca.uhn.hapi.fhir.demo</groupId>


### PR DESCRIPTION
Reverting recent change to increment hapi-fhir parent to 3.8.0. Now returning it back to 3.7.0 because 3.8.0 has not yet been published on maven (according to https://search.maven.org/artifact/ca.uhn.hapi.fhir/hapi-fhir/)