### PR TITLE
Containerize maven build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.6.1 as war
 COPY . .
 RUN mvn package
 
-FROM jetty:9-jre8-alpine
+FROM jetty:9-jre11
 USER jetty:jetty
 COPY --from=war /target/hapi-fhir-jpaserver.war /var/lib/jetty/webapps/hapi-fhir-jpaserver.war
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
+FROM maven:3.6.1 as war
+COPY . .
+RUN mvn package
+
 FROM jetty:9-jre8-alpine
 USER jetty:jetty
-ADD ./target/hapi-fhir-jpaserver.war /var/lib/jetty/webapps/hapi-fhir-jpaserver.war
+COPY --from=war /target/hapi-fhir-jpaserver.war /var/lib/jetty/webapps/hapi-fhir-jpaserver.war
 EXPOSE 8080

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-mvn package && \
-  docker build -t hapi-fhir/hapi-fhir-jpaserver-starter .
-


### PR DESCRIPTION
I don't typically keep the Java toolchain installed locally and found these changes convenient.

Please let me know if you have any thoughts!

---
* Run maven build process inside prerequisite [docker stage](https://docs.docker.com/develop/develop-images/multistage-build/)
* Remove `build-docker-image.sh` wrapper (only `docker build` is required now)
* Update base images
  * Update to JDK 11 in jetty base image
  * Use Debian-based base images (instead of Alpine) for least developer surprise
