### PR TITLE
Cors fix

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -42,7 +42,7 @@ public class HapiProperties {
     static final String TESTER_CONFIG_REFUSE_TO_FETCH_THIRD_PARTY_URLS = "tester.config.refuse_to_fetch_third_party_urls";
     static final String CORS_ENABLED = "cors.enabled";
     static final String CORS_ALLOWED_ORIGIN = "cors.allowed_origin";
-    static final String CORS_ALLOWED_CREDENTIALS = "hapi.properties";
+    static final String CORS_ALLOW_CREDENTIALS = "cors.allowCredentials";
     static final String ALLOW_CONTAINS_SEARCHES = "allow_contains_searches";
     static final String ALLOW_OVERRIDE_DEFAULT_SEARCH_PARAMS = "allow_override_default_search_params";
     static final String EMAIL_FROM = "email.from";
@@ -326,6 +326,6 @@ public class HapiProperties {
     }
 
     public static Boolean getCorsAllowedCredentials() {
-        return HapiProperties.getBooleanProperty(CORS_ALLOWED_CREDENTIALS, false);
+        return HapiProperties.getBooleanProperty(CORS_ALLOW_CREDENTIALS, false);
     }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -42,6 +42,7 @@ public class HapiProperties {
     static final String TESTER_CONFIG_REFUSE_TO_FETCH_THIRD_PARTY_URLS = "tester.config.refuse_to_fetch_third_party_urls";
     static final String CORS_ENABLED = "cors.enabled";
     static final String CORS_ALLOWED_ORIGIN = "cors.allowed_origin";
+    static final String CORS_ALLOWED_CREDENTIALS = "hapi.properties";
     static final String ALLOW_CONTAINS_SEARCHES = "allow_contains_searches";
     static final String ALLOW_OVERRIDE_DEFAULT_SEARCH_PARAMS = "allow_override_default_search_params";
     static final String EMAIL_FROM = "email.from";
@@ -322,5 +323,9 @@ public class HapiProperties {
     public static Long getReuseCachedSearchResultsMillis() {
         String value = HapiProperties.getProperty(REUSE_CACHED_SEARCH_RESULTS_MILLIS, "-1");
         return Long.valueOf(value);
+    }
+
+    public static Boolean getCorsAllowedCredentials() {
+        return HapiProperties.getBooleanProperty(CORS_ALLOWED_CREDENTIALS, false);
     }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -28,6 +28,7 @@ import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Meta;
 import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.cors.CorsConfiguration;
 
 import javax.servlet.ServletException;
@@ -185,18 +186,25 @@ public class JpaRestfulServer extends RestfulServer {
         // to your specific needs
         if (HapiProperties.getCorsEnabled()) {
             CorsConfiguration config = new CorsConfiguration();
+            config.addAllowedHeader(HttpHeaders.ORIGIN);
+            config.addAllowedHeader(HttpHeaders.ACCEPT);
+            config.addAllowedHeader(HttpHeaders.CONTENT_TYPE);
+            config.addAllowedHeader(HttpHeaders.AUTHORIZATION);
+            config.addAllowedHeader(HttpHeaders.CACHE_CONTROL);
             config.addAllowedHeader("x-fhir-starter");
-            config.addAllowedHeader("Origin");
-            config.addAllowedHeader("Accept");
             config.addAllowedHeader("X-Requested-With");
-            config.addAllowedHeader("Content-Type");
             config.addAllowedHeader("Prefer");
-
+            String allAllowedCORSOrigins = HapiProperties.getCorsAllowedOrigin();
+            Arrays.stream(allAllowedCORSOrigins.split(",")).forEach(o -> {
+                config.addAllowedOrigin(o);
+            });
             config.addAllowedOrigin(HapiProperties.getCorsAllowedOrigin());
 
             config.addExposedHeader("Location");
             config.addExposedHeader("Content-Location");
-            config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+            config.setAllowedMethods(
+                Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD"));
+            config.setAllowCredentials(HapiProperties.getCorsAllowedCredentials());
 
             // Create the interceptor and register it
             CorsInterceptor interceptor = new CorsInterceptor(config);

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -1,7 +1,7 @@
 # Adjust this to set the version of FHIR supported by this server. See
 # FhirVersionEnum for a list of available constants. Example values include
 # DSTU2, DSTU3, R4.
-fhir_version=DSTU3
+fhir_version=R4
 
 # This is the address that the FHIR server will report as its own address.
 # If this server will be deployed (for example) to an internet accessible

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -1,7 +1,7 @@
 # Adjust this to set the version of FHIR supported by this server. See
 # FhirVersionEnum for a list of available constants. Example values include
 # DSTU2, DSTU3, R4.
-fhir_version=R4
+fhir_version=DSTU3
 
 # This is the address that the FHIR server will report as its own address.
 # If this server will be deployed (for example) to an internet accessible
@@ -51,6 +51,9 @@ hibernate.search.default.indexBase=target/lucenefiles
 hibernate.search.lucene_version=LUCENE_CURRENT
 tester.config.refuse_to_fetch_third_party_urls=false
 cors.enabled=true
+cors.allowCredentials=true
+# Supports multiple, comma separated allowed origin entries
+# cors.allowed_origin=http://localhost:8080,https://localhost:8080,https://fhirtest.uhn.ca
 cors.allowed_origin=*
 
 ##################################################

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -54,7 +54,7 @@ cors.enabled=true
 cors.allowCredentials=true
 # Supports multiple, comma separated allowed origin entries
 # cors.allowed_origin=http://localhost:8080,https://localhost:8080,https://fhirtest.uhn.ca
-cors.allowed_origin=*
+cors.allow_origin=*
 
 ##################################################
 # Subscriptions


### PR DESCRIPTION
Using cors.allowed.origin=* together with credentials is forbidden:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Server-Side_Access_Control
https://www.w3.org/TR/cors/

and results in a 403 response.
This PR adds support for allowCredentials, and a list of allowed origins.
The spring CORS filter will check if the origin is in this list an returns the appropriate url.