### PR TITLE
Updating Dockerfile to build the app from the ground up

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+ENV PATH="/tmp/apache-maven-3.6.0/bin:${PATH}"
+
+WORKDIR /tmp
+RUN apt-get update && \
+	apt-get install git -y && \
+	apt-get install sed -y && \
+	apt-get install wget -y && \
+    apt-get install openjdk-11-jdk -y
+
+RUN wget https://www-us.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz && tar xzf apache-maven-3.6.2-bin.tar.gz
+RUN export PATH=/tmp/apache-maven-3.6.2/bin:${PATH}

--- a/docker-build.bat
+++ b/docker-build.bat
@@ -1,0 +1,1 @@
+docker build --tag hapiproject/hapi:latest --tag hapiproject/hapi:4.1 -m 4g .


### PR DESCRIPTION
These are the Dockerfiles that I used for the documentation here: https://hub.docker.com/repository/docker/hapiproject/hapi

They're also the same Dockerfiles I'm using in my own environment to build and deploy HAPI. They're pretty flexible files, and perform the compile directly in docker, rather than requiring the user to compile the application first and then build the docker image. The advantage to this, is that the docker image is an exact representation of stuff on github, rather than potentially having custom from the machine running the docker build.