### PR TITLE
Support MariaDB database compliant to Apache 2.0 License

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# MySQL and MariaDB configuration
+MYSQL_DATABASE=hapi
+MYSQL_USER=admin
+MYSQL_PASSWORD=admin
+MYSQL_ROOT_PASSWORD=admin

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ local.properties
 .settings/
 .loadpath
 .recommenders
+.classpath
+.project
 
 # External tool builders
 .externalToolBuilders/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ To configure the starter app to use MySQL, instead of the default Derby, update 
 - datasource.username=admin
 - datasource.password=admin
 
+
+### MariaDB configuration
+
+To configure the starter app to use MariaDB, instead of the default Derby, update the hapi.properties file to have the following:
+
+- datasource.driver=org.mariadb.jdbc.Driver
+- datasource.url=jdbc:mariadb://localhost:3306/hapi_dstu3
+- hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
+- datasource.username=admin
+- datasource.password=admin
+
 ### PostgreSQL configuration
 
 To configure the starter app to use PostgreSQL, instead of the default Derby, update the hapi.properties file to have the following:
@@ -105,14 +116,24 @@ reached at http://localhost:8080/hapi-fhir-jpaserver/.
 In order to use another port, change the `ports` parameter
 inside `docker-compose.yml` to `8888:8080`, where 8888 is a port of your choice.
 
-The docker compose set also includes my MySQL database, if you choose to use MySQL instead of derby, change the following
-properties in hapi.properties:
+The docker compose set also includes my MySQL and MariaDB database, if you choose to use MySQL instead of derby, change the following properties in hapi.properties. Database parameters can also be configured also in `.env` environment file:
+
+**MySQL**
 
 - datasource.driver=com.mysql.jdbc.Driver
 - datasource.url=jdbc:mysql://hapi-fhir-mysql:3306/hapi
 - hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 - datasource.username=admin
 - datasource.password=admin
+
+**MariaDB**
+
+- datasource.driver=org.mariadb.jdbc.Driver
+- datasource.url=jdbc:mariadb://localhost:3306/hapi
+- hibernate.dialect=org.hibernate.dialect.MariaDB103Dialect
+- datasource.username=admin
+- datasource.password=admin
+
 
 ## Running hapi-fhir-jpaserver-example in Tomcat from IntelliJ
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,16 +6,29 @@ services:
     restart: on-failure
     ports:
       - "8080:8080"
+      
   hapi-fhir-mysql:
     image: mysql:latest
     container_name: hapi-fhir-mysql
     restart: always
     environment:
-      MYSQL_DATABASE: 'hapi'
-      MYSQL_USER: 'admin'
-      MYSQL_PASSWORD: 'admin'
-      MYSQL_ROOT_PASSWORD: 'admin'
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     volumes:
       - hapi-fhir-mysql:/var/lib/mysql
+      
+  hapi-fhir-mariadb:
+    image: mariadb/server:10.4
+    container_name: hapi-fhir-mariadb
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    volumes:
+      - hapi-fhir-mysql:/var/lib/mysql
+      
 volumes:
   hapi-fhir-mysql:

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,13 @@
             <artifactId>postgresql</artifactId>
             <version>42.2.9</version>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>2.5.4</version>
+        </dependency>
+        
         <!-- Needed for Email subscriptions -->
         <dependency>
             <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
## Proposed Changes

- JPA Starter can use MariaDB database with the proper configuration
- docker-compose is modified and `.env` file is added
- README file includes how to configure MariaDB

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [ ] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Fixes #86  

## What is the new behavior?

- JPA Starter can be used with MariaDB databases
- It also can be deployed using docker-compose

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Additional information

I uploaded successfully a bunch of resources but I did not thoroughly test it