### PR TITLE
Adding environment variables to override hapi properties file settings

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.defaultString;
@@ -138,7 +139,10 @@ public class HapiProperties {
     if (overrideProps != null) {
       properties.putAll(overrideProps);
     }
-    properties.putAll(System.getenv());
+    properties.putAll(System.getenv().entrySet()
+                                     .stream()
+                                     .filter(e -> e.getValue() != null && properties.containsKey(e.getKey()))
+                                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     return properties;
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -138,6 +138,7 @@ public class HapiProperties {
     if (overrideProps != null) {
       properties.putAll(overrideProps);
     }
+    properties.putAll(System.getenv());
     return properties;
   }
 


### PR DESCRIPTION
I am happy with most of the hapi properties :-). There is today possibility to override hapi properties by   `-Dhapi.properties` in `JAVA_OPTS` environment variable.
However it is very convenient to just override some of the properties in your container using kubernetes manifest file for your deployment. Like in this example, where I override default DB used by HAPI and set desired version.
```
        env: 
        - name: HAPI_DATABASE_NAME
          value: HAPI_R4
        - name: datasource.url
          value: "jdbc:sqlserver://mssql-database;databaseName=$(HAPI_DATABASE_NAME)"
        - name: datasource.driver
          value: com.microsoft.sqlserver.jdbc.SQLServerDriver
        - name: hibernate.dialect
          value: org.hibernate.dialect.SQLServer2012Dialect
        - name: server_address
          value: {{http-scheme}}://{{base-url}}{{hapi-r4-base-uri}}
        - name: fhir_version
          value: R4
        - name: datasource.username
          valueFrom:
            secretKeyRef:
              name: hapi-db-secret-name
              key: username  
        - name: datasource.password
          valueFrom:
            secretKeyRef:
              name: hapi-db-secret-name
              key: password 
```

So instead of keeping and mounting different hapi.properties files or having customized files build into docker image, I can use one default docker image and customize in kubernetes manifest files as needed. I.e. running DSTU3 and DSTU2 version side by side using the same container. No matter what solution you use to maintain your manifest files (helm, kustomize...), this works.

To have that possibility, environment variables have to be loaded and override properties from hapi.properties file. Solution provided here is very simple and works, but I guess could be improved e.g. by adding only variables that are "known" in hapi.properties file. I am actually using image with this change and it would be great, if this could be part of default source code.