### PR TITLE
(fix) Remove duplicate auto create placeholder references property

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
@@ -38,7 +38,6 @@ public class FhirServerConfigCommon {
   private Boolean allowMultipleDelete = HapiProperties.getAllowMultipleDelete();
   private Boolean allowExternalReferences = HapiProperties.getAllowExternalReferences();
   private Boolean expungeEnabled = HapiProperties.getExpungeEnabled();
-  private Boolean allowPlaceholderReferences = HapiProperties.getAllowPlaceholderReferences();
   private Boolean subscriptionRestHookEnabled = HapiProperties.getSubscriptionRestHookEnabled();
   private Boolean subscriptionEmailEnabled = HapiProperties.getSubscriptionEmailEnabled();
   private Boolean allowOverrideDefaultSearchParams = HapiProperties.getAllowOverrideDefaultSearchParams();
@@ -60,7 +59,7 @@ public class FhirServerConfigCommon {
     ourLog.info("Server configured to " + (this.allowMultipleDelete ? "allow" : "deny") + " multiple deletes");
     ourLog.info("Server configured to " + (this.allowExternalReferences ? "allow" : "deny") + " external references");
     ourLog.info("Server configured to " + (this.expungeEnabled ? "enable" : "disable") + " expunges");
-    ourLog.info("Server configured to " + (this.allowPlaceholderReferences ? "allow" : "deny") + " placeholder references");
+    ourLog.info("Server configured to " + (this.autoCreatePlaceholderReferenceTargets ? "allow" : "deny") + " placeholder references");
     ourLog.info("Server configured to " + (this.allowOverrideDefaultSearchParams ? "allow" : "deny") + " overriding default search params");
 
     if (this.emailEnabled) {
@@ -100,7 +99,6 @@ public class FhirServerConfigCommon {
     retVal.setAllowMultipleDelete(this.allowMultipleDelete);
     retVal.setAllowExternalReferences(this.allowExternalReferences);
     retVal.setExpungeEnabled(this.expungeEnabled);
-    retVal.setAutoCreatePlaceholderReferenceTargets(this.allowPlaceholderReferences);
     retVal.setEmailFromAddress(this.emailFrom);
 
     Integer maxFetchSize = HapiProperties.getMaximumFetchSize();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -376,10 +376,6 @@ public class HapiProperties {
     return HapiProperties.getProperty(SERVER_ID, "home");
   }
 
-  public static Boolean getAllowPlaceholderReferences() {
-    return HapiProperties.getBooleanProperty(ALLOW_PLACEHOLDER_REFERENCES, true);
-  }
-
   public static Boolean getSubscriptionEmailEnabled() {
     return HapiProperties.getBooleanProperty(SUBSCRIPTION_EMAIL_ENABLED, false);
   }

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -28,7 +28,6 @@ allow_contains_searches=true
 allow_multiple_delete=true
 allow_external_references=true
 allow_cascading_deletes=true
-allow_placeholder_references=true
 expunge_enabled=true
 persistence_unit_name=HAPI_PU
 logger.name=fhirtest.access


### PR DESCRIPTION
I have removed the extra and useless property `allow_placeholder_references` , that adds confusion to `auto_create_placeholder_reference_targets`. Please review and let me know your feedback

This closes #98 