### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Server will then be accessible at http://localhost:8888/ and eg. http://localhos
 
 ### Using Spring Boot
 ```bash
-mvn clean package spring-boot:repackage -Pboot && java -jar target/hapi-fhir-jpaserver.war
+mvn clean package spring-boot:repackage -Pboot && java -jar target/ROOT.war
 ```
 Server will then be accessible at http://localhost:8080/ and eg. http://localhost:8080/fhir/metadata. Remember to adjust you overlay configuration in the application.yaml to eg.
 


### PR DESCRIPTION
The rename from hapi-fhir-jpaserver to ROOT as per ee337296eeb1adbe4faf21e295d55757767009bf requires that the new war file is specified which is now ROOT.war