### PR TITLE
Remove duplicated batch key

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,10 +26,6 @@ spring:
       hibernate.search.default.indexBase: target/lucenefiles
       hibernate.search.lucene_version: LUCENE_CURRENT
 
-  batch:
-    job:
-      enabled: false
-
 hapi:
   fhir:
     defer_indexing_for_codesystems_of_size: 101


### PR DESCRIPTION
I removed the duplicated key `spring.batch` in the application.yaml in order to start hapi properly.
