### PR TITLE
remove duplicate entry in yml for batch.job.enabled

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,11 +25,6 @@ spring:
       hibernate.search.default.directory_provider: filesystem
       hibernate.search.default.indexBase: target/lucenefiles
       hibernate.search.lucene_version: LUCENE_CURRENT
-
-  batch:
-    job:
-      enabled: false
-
 hapi:
   fhir:
     defer_indexing_for_codesystems_of_size: 101


### PR DESCRIPTION
there are in application.yml duplicate keys  for batch:	job:	enabled: false which raises an exception during startup:

```
Caused by: org.yaml.snakeyaml.constructor.DuplicateKeyException: while constructing a mapping
 in 'reader', line 2, column 3:
      batch:
      ^
found duplicate key batch
 in 'reader', line 29, column 3:
      batch:
      ^
```
this PR removes one of the entries