### PR TITLE
Docker buid - heap memory error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY pom.xml .
 RUN mvn -ntp dependency:go-offline
 
 COPY src/ /tmp/hapi-fhir-jpaserver-starter/src/
+RUN set MAVEN_OPTS="-Xmx1024m"
 RUN mvn clean install -DskipTests
 
 FROM tomcat:9.0.38-jdk11-openjdk-slim-buster


### PR DESCRIPTION
When building in Docker, we sometimes face a heap memory running out when compiling the WAR file.
Setting the MAVEN_OPTS="-Xmx1024m" resolves this