### PR TITLE
Remove webjars versions specified in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,37 +177,30 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>Eonasdan-bootstrap-datetimepicker</artifactId>
-            <version>4.17.43</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>font-awesome</artifactId>
-            <version>5.8.2</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>awesome-bootstrap-checkbox</artifactId>
-            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jstimezonedetect</artifactId>
-            <version>1.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>select2</artifactId>
-            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>moment</artifactId>
-            <version>2.15.1</version>
         </dependency>
 
         <!-- The following dependencies are only needed for automated unit tests, you do not neccesarily need them to run the example. -->


### PR DESCRIPTION
The webjar versions are specified in the parent POM. They should not be explicitly mentioned in our POM.