### PR TITLE
Fixed indentation error in application.yaml

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,11 +84,11 @@ hapi:
 #    partitioning:
 #      allow_references_across_partitions: false
 #      partitioning_include_in_search_hashes: false
-     cors:
-       allow_Credentials: true
-       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
-       allowed_origin:
-       - '*'
+    cors:
+      allow_Credentials: true
+      # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
+      allowed_origin:
+        - '*'
 
     # Search coordinator thread pool sizes
     search-coord-core-pool-size: 20


### PR DESCRIPTION
There was a small indentation error in the application.yaml causing the application startup to fail

We could introduce additional tooling as part of the GitHub Workflows to lint yaml and detect these potential problems earlier (eg https://github.com/github/super-linter).