### PR TITLE
Corrected subscription environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,11 +317,11 @@ It is important to use MySQL5Dialect when using MySQL version 5+.
 
 The server may be configured with subscription support by enabling properties in the [application.yaml](https://github.com/hapifhir/hapi-fhir-jpaserver-starter/blob/master/src/main/resources/application.yaml) file:
 
-- `hapi.fhir.subscription.resthook.enabled` - Enables REST Hook subscriptions, where the server will make an outgoing connection to a remote REST server
+- `hapi.fhir.subscription.resthook_enabled` - Enables REST Hook subscriptions, where the server will make an outgoing connection to a remote REST server
 
 - `hapi.fhir.subscription.email.*` - Enables email subscriptions. Note that you must also provide the connection details for a usable SMTP server.
 
-- `hapi.fhir.subscription.websocket.enabled` - Enables websocket subscriptions. With this enabled, your server will accept incoming websocket connections on the following URL (this example uses the default context path and port, you may need to tweak depending on your deployment environment): [ws://localhost:8080/websocket](ws://localhost:8080/websocket)
+- `hapi.fhir.subscription.websocket_enabled` - Enables websocket subscriptions. With this enabled, your server will accept incoming websocket connections on the following URL (this example uses the default context path and port, you may need to tweak depending on your deployment environment): [ws://localhost:8080/websocket](ws://localhost:8080/websocket)
 
 ## Enabling CQL
 


### PR DESCRIPTION
According to the default application.yaml, it's `hapi.fhir.subscription.resthook_enabled` (with the underscore). I've tested this with the latest docker container and it works. Setting `hapi.fhir.subscription.resthook.enabled=true` does not enable subscriptions. I spent a lot of time breaking my head over this simple variable name. Hopefully, this will help someone.