### PR TITLE
add <attachClasses>true</attachClasses> to  maven-war-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,7 @@
                             <Build-Time>${maven.build.timestamp}</Build-Time>
                         </manifestEntries>
                     </archive>
+                    <attachClasses>true</attachClasses>
                     <overlays>
                         <overlay>
                             <groupId>ca.uhn.hapi.fhir</groupId>


### PR DESCRIPTION
Please consider adding a classes jar artifact, as illustrated here.

The classes jar can be a useful dependency for a project that implements a hapi-fhir server with no test overlay.  It also enables clean separation between code maintained here and specialized code that isn't tightly bound to this project (e.g. custom AuthorizationInterceptor, custom Dockerfile, etc.).