### PR TITLE
mysql docker setup patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ spring:
   jpa:
     hibernate.physical_naming_strategy: NAME_OF_PREFERRED_STRATEGY
 ```
+On linux systems or when using docker mysql containers, it will be necessary to review the case-sensitive setup for
+mysql schema identifiers. See  https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html. We suggest you
+set `lower_case_table_names=1` during mysql startup.
 
 ### PostgreSQL configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
   hapi-fhir-mysql:
     image: mysql:latest
     container_name: hapi-fhir-mysql
+    #https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html
+    command: --lower_case_table_names=1
     restart: always
     environment:
       MYSQL_DATABASE: 'hapi'


### PR DESCRIPTION
Mysql docker setup - forcing mysql identifiers (database, table, triggers) naming to lowercase and name comparison to caseinsensitive, so hibernate queries can work even when referencing upper cased table names