### PR TITLE
Adding dependency to snakeyaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>postgresql</artifactId>
             <version>42.2.9</version>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.28</version>
+        </dependency>
 
         <!-- Needed for Email subscriptions -->
         <dependency>


### PR DESCRIPTION
At least a few people (myself included) have had problems launching `hapi-fhir-jpaserver-starter` without having snakeyaml added as an explicit dependency.
I'd like merge this change to add it as a dependency. After it is merged, I'd like to delete the tag for 5.4.0 and re-tag it on the HEAD of `master` (including this change) as 5.4.0.
This will cause the docker image to rebuild for 5.4.0, and should solve the problem for at least a few people, if not more.
Please let me know if you're ok with me deleting the 5.4.0 tag and re-creating it on the HEAD of master when you approve/reject this merge request.