### PR TITLE
Adds ability to control the number of executor threads through environment variables.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM maven:3.6.3-jdk-11-slim as build-hapi
 WORKDIR /tmp/hapi-fhir-jpaserver-starter
 
 COPY pom.xml .
+COPY server.xml .
 RUN mvn -ntp dependency:go-offline
 
 COPY src/ /tmp/hapi-fhir-jpaserver-starter/src/
@@ -26,6 +27,9 @@ FROM tomcat:9.0.38-jdk11-openjdk-slim-buster
 
 RUN mkdir -p /data/hapi/lucenefiles && chmod 775 /data/hapi/lucenefiles
 COPY --from=build-hapi /tmp/hapi-fhir-jpaserver-starter/target/*.war /usr/local/tomcat/webapps/
+
+COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
+COPY server.xml /usr/local/tomcat/conf/server.xml
 
 EXPOSE 8080
 

--- a/catalina.properties
+++ b/catalina.properties
@@ -1,0 +1,208 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageAccess unless the
+# corresponding RuntimePermission ("accessClassInPackage."+package) has
+# been granted.
+package.access=sun.,org.apache.catalina.,org.apache.coyote.,org.apache.jasper.,org.apache.tomcat.
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageDefinition unless the
+# corresponding RuntimePermission ("defineClassInPackage."+package) has
+# been granted.
+#
+# by default, no packages are restricted for definition, and none of
+# the class loaders supplied with the JDK call checkPackageDefinition.
+#
+package.definition=sun.,java.,org.apache.catalina.,org.apache.coyote.,\
+org.apache.jasper.,org.apache.naming.,org.apache.tomcat.
+
+#
+#
+# List of comma-separated paths defining the contents of the "common"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank,the JVM system loader will be used as Catalina's "common"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values are enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+common.loader="${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"
+
+#
+# List of comma-separated paths defining the contents of the "server"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank, the "common" loader will be used as Catalina's "server"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+server.loader=
+
+#
+# List of comma-separated paths defining the contents of the "shared"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_BASE path or absolute. If left as blank,
+# the "common" loader will be used as Catalina's "shared" loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+# Please note that for single jars, e.g. bar.jar, you need the URL form
+# starting with file:.
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+shared.loader=
+
+# Default list of JAR files that should not be scanned using the JarScanner
+# functionality. This is typically used to scan JARs for configuration
+# information. JARs that do not contain such information may be excluded from
+# the scan to speed up the scanning process. This is the default list. JARs on
+# this list are excluded from all scans. The list must be a comma separated list
+# of JAR file names.
+# The list of JARs to skip may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+# The JARs listed below include:
+# - Tomcat Bootstrap JARs
+# - Tomcat API JARs
+# - Catalina JARs
+# - Jasper JARs
+# - Tomcat JARs
+# - Common non-Tomcat JARs
+# - Test JARs (JUnit, Cobertura and dependencies)
+tomcat.util.scan.StandardJarScanFilter.jarsToSkip=\
+annotations-api.jar,\
+ant-junit*.jar,\
+ant-launcher.jar,\
+ant.jar,\
+asm-*.jar,\
+aspectj*.jar,\
+bootstrap.jar,\
+catalina-ant.jar,\
+catalina-ha.jar,\
+catalina-ssi.jar,\
+catalina-storeconfig.jar,\
+catalina-tribes.jar,\
+catalina.jar,\
+cglib-*.jar,\
+cobertura-*.jar,\
+commons-beanutils*.jar,\
+commons-codec*.jar,\
+commons-collections*.jar,\
+commons-daemon.jar,\
+commons-dbcp*.jar,\
+commons-digester*.jar,\
+commons-fileupload*.jar,\
+commons-httpclient*.jar,\
+commons-io*.jar,\
+commons-lang*.jar,\
+commons-logging*.jar,\
+commons-math*.jar,\
+commons-pool*.jar,\
+dom4j-*.jar,\
+easymock-*.jar,\
+ecj-*.jar,\
+el-api.jar,\
+geronimo-spec-jaxrpc*.jar,\
+h2*.jar,\
+hamcrest-*.jar,\
+hibernate*.jar,\
+httpclient*.jar,\
+icu4j-*.jar,\
+jasper-el.jar,\
+jasper.jar,\
+jaspic-api.jar,\
+jaxb-*.jar,\
+jaxen-*.jar,\
+jdom-*.jar,\
+jetty-*.jar,\
+jmx-tools.jar,\
+jmx.jar,\
+jsp-api.jar,\
+jstl.jar,\
+jta*.jar,\
+junit-*.jar,\
+junit.jar,\
+log4j*.jar,\
+mail*.jar,\
+objenesis-*.jar,\
+oraclepki.jar,\
+oro-*.jar,\
+servlet-api-*.jar,\
+servlet-api.jar,\
+slf4j*.jar,\
+taglibs-standard-spec-*.jar,\
+tagsoup-*.jar,\
+tomcat-api.jar,\
+tomcat-coyote.jar,\
+tomcat-dbcp.jar,\
+tomcat-i18n-*.jar,\
+tomcat-jdbc.jar,\
+tomcat-jni.jar,\
+tomcat-juli-adapters.jar,\
+tomcat-juli.jar,\
+tomcat-util-scan.jar,\
+tomcat-util.jar,\
+tomcat-websocket.jar,\
+tools.jar,\
+websocket-api.jar,\
+wsdl4j*.jar,\
+xercesImpl.jar,\
+xml-apis.jar,\
+xmlParserAPIs-*.jar,\
+xmlParserAPIs.jar,\
+xom-*.jar
+
+# Default list of JAR files that should be scanned that overrides the default
+# jarsToSkip list above. This is typically used to include a specific JAR that
+# has been excluded by a broad file name pattern in the jarsToSkip list.
+# The list of JARs to scan may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+tomcat.util.scan.StandardJarScanFilter.jarsToScan=\
+log4j-taglib*.jar,\
+log4j-web*.jar,\
+log4javascript*.jar,\
+slf4j-taglib*.jar
+
+# String cache configuration.
+tomcat.util.buf.StringCache.byte.enabled=true
+#tomcat.util.buf.StringCache.char.enabled=true
+#tomcat.util.buf.StringCache.trainThreshold=500000
+#tomcat.util.buf.StringCache.cacheSize=5000
+
+org.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.Digester$EnvironmentPropertySource

--- a/server.xml
+++ b/server.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" 
+               maxThreads="${server.tomcat.max-threads}"
+               minSpareThreads="${server.tomcat.min-spare-threads}" /> 
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>


### PR DESCRIPTION
Currently, the HAPI FHIR JPA server has a fixed number (10) of executor threads.  It is not possible to change this default without forking the server.  We are currently unable to completely utilize the available CPU and memory in our clusters  because we are unable to tune the number of executor threads to something more appropriate.

This fixes the issue by copying the current Tomcat default server.xml and catalina.properties files into the root of the JPA server and modifying them such that:

1.  Properties in server.xml are taken from the local environment variables
2.  server.tomcat.max-threads and server.tomcat.min-spare-threads control the maximum and minimum number of executor threads available on the server by modifying the default connector in server.xml.

In the long term, this is probably a responsible thing to do because more configuration options could be exposed to users of the JPA server through the server.xml file as necessary.

This is not a breaking change and does not affect the behavior of the JPA server unless these environment variables are set.

You may test to confirm as such:

```bash
docker build .
```
(note the build hash)

```bash
docker run -p 8080:8080 hash-you-noted-above
```
See that you still have 10 executor threads, the default behavior.

```bash
docker run -p 8080:8080 -e server.tomcat.max-threads=20 -e server.tomcat.min-spare-threads=20 hash-you-noted-above
```
See that you now have 20 executor threads, thus allowing you to tune your server's parallelism.