### PR TITLE
only push build images to DockerHub

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -17,7 +17,6 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: |
-            ghcr.io/hapifhir/hapi
             docker.io/hapiproject/hapi
           tag-sha: false
           tag-match: "v(.*)"
@@ -27,7 +26,6 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: |
-            ghcr.io/hapifhir/hapi
             docker.io/hapiproject/hapi
           tag-sha: false
           tag-match: "v(.*)"
@@ -42,13 +40,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
per discussion in https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/268, this disables pushing the image to the GitHub container registry until permissions are sorted out.