### PR TITLE
Updated to HAPI FHIR 5.5.1 and updated workflows to build ARM-compatible images

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  IMAGES: docker.io/hapiproject/hapi
+  PLATFORMS: linux/amd64,linux/arm64/v8
+
 jobs:
   build:
     name: Build
@@ -14,32 +18,37 @@ jobs:
     steps:
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
-          images: |
-            docker.io/hapiproject/hapi
-          tag-sha: false
-          tag-match: "v(.*)"
-      # waiting for https://github.com/crazy-max/ghaction-docker-meta/issues/13 for a cleaner solution
+          images: ${{ env.IMAGES }}
+          tags: |
+            type=match,pattern=image-(.*),group=1,enable=${{github.event_name != 'pull_request'}}
+            type=sha
+
       - name: Docker distroless meta
         id: docker_distroless_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
-          images: |
-            docker.io/hapiproject/hapi
-          tag-sha: false
-          tag-match: "v(.*)"
-          sep-tags: -distroless,
+          images: ${{ env.IMAGES }}
+          tags: |
+            type=match,pattern=image-(.*),group=1,enable=${{github.event_name != 'pull_request'}}
+            type=sha
+          flavor: |
+            suffix=-distroless,onlatest=true
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -47,6 +56,7 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
@@ -56,6 +66,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          platforms: ${{ env.PLATFORMS }}
+
       - name: Build and push distroless
         id: docker_build_distroless
         uses: docker/build-push-action@v2
@@ -63,10 +75,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_distroless_meta.outputs.tags }}-distroless
+          tags: ${{ steps.docker_distroless_meta.outputs.tags }}
           labels: ${{ steps.docker_distroless_meta.outputs.labels }}
+          platforms: ${{ env.PLATFORMS }}
           target: release-distroless
-      - name: Print image digests
-        run: |
-          echo ${{ steps.docker_build.outputs.digest }}
-          echo ${{ steps.docker_build_distroless.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3-jdk-11-slim as build-hapi
+FROM maven:3.8.2-jdk-11-slim as build-hapi
 WORKDIR /tmp/hapi-fhir-jpaserver-starter
 
 COPY pom.xml .
@@ -13,9 +13,8 @@ RUN mvn package spring-boot:repackage -Pboot
 RUN mkdir /app && \
     cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.war
 
-FROM gcr.io/distroless/java-debian10:11 AS release-distroless
+FROM gcr.io/distroless/java-debian11:11 AS release-distroless
 COPY --chown=nonroot:nonroot --from=build-distroless /app /app
-EXPOSE 8080
 # 65532 is the nonroot user's uid
 # used here instead of the name to allow Kubernetes to easily detect that the container
 # is running as a non-root (uid != 0) user.
@@ -23,7 +22,7 @@ USER 65532:65532
 WORKDIR /app
 CMD ["/app/main.war"]
 
-FROM tomcat:9.0.38-jdk11-openjdk-slim-buster
+FROM tomcat:9.0.53-jdk11-openjdk-slim-bullseye
 
 RUN mkdir -p /data/hapi/lucenefiles && chmod 775 /data/hapi/lucenefiles
 COPY --from=build-hapi /tmp/hapi-fhir-jpaserver-starter/target/*.war /usr/local/tomcat/webapps/

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-		  <version>5.5.0</version>
+		  <version>5.5.1</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>


### PR DESCRIPTION
1. Bumped HAPI FHIR to 5.5.1
2. Bumped all Dockerfile base images to latest (and Debian 11)
3. Refactored CI to
    1. use newer versions of the docker/metadata-action
    2. build ARM-compatible variants of the images (Closes #276). This makes the CI significantly slower. If desired, we could disable it for PRs and only build ARM variants on releases.
    3. also build and push images tagged with the commit SHA. e.g. this will tag images on pushes to master as `sha-5a0e725` and `sha-5a0e725-distroless`. This makes it easer to test fixes/commits sooner
    4. as before, any tag called `image/v1.2.3` will create images tagged as `v1.2.3` and `v1.2.3-distroless`. See https://github.com/chgl/hapi-fhir-jpaserver-starter/pkgs/container/hapi for an example of tags created while I debugged the workflow.


