### PR TITLE
Feature/update docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN mkdir /app && cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.
 
 
 ########### bitnami tomcat version is suitable for debugging and comes with a shell
+########### it can be built using eg. `docker build --target tomcat .`
 FROM bitnami/tomcat:9.0 as tomcat
 
 RUN rm -rf /opt/bitnami/tomcat/webapps/ROOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.2-jdk-11-slim as build-hapi
+FROM maven:3.8-openjdk-17-slim as build-hapi
 WORKDIR /tmp/hapi-fhir-jpaserver-starter
 
 COPY pom.xml .
@@ -10,10 +10,25 @@ RUN mvn clean install -DskipTests
 
 FROM build-hapi AS build-distroless
 RUN mvn package spring-boot:repackage -Pboot
-RUN mkdir /app && \
-    cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.war
+RUN mkdir /app && cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.war
 
-FROM gcr.io/distroless/java-debian11:11 AS release-distroless
+
+########### bitnami tomcat version is suitable for debugging and comes with a shell
+FROM bitnami/tomcat:9.0 as tomcat
+
+RUN rm -rf /opt/bitnami/tomcat/webapps/ROOT
+RUN rm -rf /opt/bitnami/tomcat/webapps_default/ROOT
+
+RUN mkdir -p /opt/bitnami/hapi/data/hapi/lucenefiles && chmod 775 /opt/bitnami/hapi/data/hapi/lucenefiles
+COPY --from=build-hapi --chown=1001:1001 /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /opt/bitnami/tomcat/webapps_default/ROOT.war
+
+COPY --chown=1001:1001 catalina.properties /opt/bitnami/tomcat/conf/catalina.properties
+COPY --chown=1001:1001 server.xml /opt/bitnami/tomcat/conf/server.xml
+
+ENV ALLOW_EMPTY_PASSWORD=yes
+
+########### distroless brings focus on security and runs on plain spring boot - this is the default image
+FROM gcr.io/distroless/java17:nonroot as default
 COPY --chown=nonroot:nonroot --from=build-distroless /app /app
 # 65532 is the nonroot user's uid
 # used here instead of the name to allow Kubernetes to easily detect that the container
@@ -21,13 +36,3 @@ COPY --chown=nonroot:nonroot --from=build-distroless /app /app
 USER 65532:65532
 WORKDIR /app
 CMD ["/app/main.war"]
-
-FROM tomcat:9.0.53-jdk11-openjdk-slim-bullseye
-
-RUN mkdir -p /data/hapi/lucenefiles && chmod 775 /data/hapi/lucenefiles
-COPY --from=build-hapi /tmp/hapi-fhir-jpaserver-starter/target/*.war /usr/local/tomcat/webapps/
-
-COPY catalina.properties /usr/local/tomcat/conf/catalina.properties
-COPY server.xml /usr/local/tomcat/conf/server.xml
-
-CMD ["catalina.sh", "run"]


### PR DESCRIPTION
This superseeds https://github.com/hapifhir/hapi-fhir-jpaserver-starter/pull/305 and changes the default tomcat setup to the bitnami version. It also makes the image default to distroless