### PR TITLE
add dao_scheduling_enabled configuration property

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -28,6 +28,7 @@ public class AppProperties {
   private Boolean allow_multiple_delete = false;
   private Boolean allow_override_default_search_params = true;
   private Boolean auto_create_placeholder_reference_targets = false;
+  private Boolean dao_scheduling_enabled = true;
   private Boolean delete_expunge_enabled = false;
   private Boolean enable_index_missing_fields = false;
   private Boolean enable_index_contained_resource = false;
@@ -284,6 +285,14 @@ public class AppProperties {
 
   public void setDefault_page_size(Integer default_page_size) {
     this.default_page_size = default_page_size;
+  }
+
+  public Boolean getDao_scheduling_enabled() {
+    return dao_scheduling_enabled;
+  }
+
+  public void setDao_scheduling_enabled(Boolean dao_scheduling_enabled) {
+    this.dao_scheduling_enabled = dao_scheduling_enabled;
   }
 
   public Boolean getDelete_expunge_enabled() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/FhirServerConfigCommon.java
@@ -39,6 +39,7 @@ public class FhirServerConfigCommon {
     ourLog.info("Server configured to " + (appProperties.getAllow_contains_searches() ? "allow" : "deny") + " contains searches");
     ourLog.info("Server configured to " + (appProperties.getAllow_multiple_delete() ? "allow" : "deny") + " multiple deletes");
     ourLog.info("Server configured to " + (appProperties.getAllow_external_references() ? "allow" : "deny") + " external references");
+    ourLog.info("Server configured to " + (appProperties.getDao_scheduling_enabled() ? "enable" : "disable") + " DAO scheduling");
     ourLog.info("Server configured to " + (appProperties.getDelete_expunge_enabled() ? "enable" : "disable") + " delete expunges");
     ourLog.info("Server configured to " + (appProperties.getExpunge_enabled() ? "enable" : "disable") + " expunges");
     ourLog.info("Server configured to " + (appProperties.getAllow_override_default_search_params() ? "allow" : "deny") + " overriding default search params");
@@ -85,6 +86,7 @@ public class FhirServerConfigCommon {
     retVal.setAllowContainsSearches(appProperties.getAllow_contains_searches());
     retVal.setAllowMultipleDelete(appProperties.getAllow_multiple_delete());
     retVal.setAllowExternalReferences(appProperties.getAllow_external_references());
+    retVal.setSchedulingDisabled(!appProperties.getDao_scheduling_enabled());
     retVal.setDeleteExpungeEnabled(appProperties.getDelete_expunge_enabled());
     retVal.setExpungeEnabled(appProperties.getExpunge_enabled());
     if(appProperties.getSubscription() != null && appProperties.getSubscription().getEmail() != null)


### PR DESCRIPTION
This PR adds a dao_scheduling_enabled configuration property, to make the DaoConfig scheduling setting configurable.

In a clustered environment, DaoConfig scheduling should be disabled on all nodes except one.

The following message thread contains a few comments from James Agnew on the topic.

https://groups.google.com/g/hapi-fhir/c/kjY-o7hMRuo/m/ShNI3xl3AwAJ

"There are many scheduled maintenance jobs that must be executed once and only once per scheduling period. The scheduler must be disabled on all nodes except one."

"The DaoConfig one is the one that should be disabled."