### PR TITLE
Updated to HAPI FHIR version 5.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-		  <version>5.7.0</version>
+		  <version>5.7.2</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>


### PR DESCRIPTION
This updates the included HAPI FHIR version to 5.7.2.

Thanks to https://github.com/hapifhir/hapi-fhir-jpaserver-starter/pull/337, A new version of this starter image will allow me to update the liveness and readiness probes used by the Helm Chart deployment to use the out-of-the-box Spring Boot Kubernetes probes (https://docs.spring.io/spring-boot/docs/2.6.6/reference/htmlsingle/#actuator.endpoints.kubernetes-probes.external-state)