### PR TITLE
Revert accidental default activation of experimental lucene indexing

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,8 +84,8 @@ hapi:
     #    enable_repository_validating_interceptor: false
     #    enable_index_missing_fields: false
     #    enable_index_contained_resource: false
-    #    advanced_lucene_indexing: false
-    advanced_lucene_indexing: true
+    # This is an experimental feature, and does not fully support _total and other FHIR features.
+    advanced_lucene_indexing: false
 #    enforce_referential_integrity_on_delete: false
     #    enforce_referential_integrity_on_write: false
     #    etag_support_enabled: true


### PR DESCRIPTION
Lucene indexing was accidentally activated. This reverts the error.