### PR TITLE
Expose Prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,13 @@
             <version>${spring_boot_version}</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.8.5</version>
+        </dependency>
+
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health"
+        include: "health,prometheus"
 spring:
   main:
     allow-circular-references: true


### PR DESCRIPTION
This enables the Prometheus actuator endpoint to expose application metrics on `/actuator/prometheus` (https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.metrics.export.prometheus).

This endpoint is read-only and included by default. I don't believe any critical information is exposed via this endpoint, but we could also run the actuator on different port (via the `management.server.port` property) so it can be firewalled off if desired, combined with `management.endpoint.health.probes.add-additional-paths=true`, health probes can still run on the main server port (see also https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints.kubernetes-probes).