### PR TITLE
Conditionaly call the initContainers only when .postgresql.enable is true

### DIFF
--- a/charts/hapi-fhir-jpaserver/templates/deployment.yaml
+++ b/charts/hapi-fhir-jpaserver/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+    {{ if $.Values.postgresql.enabled }}
       initContainers:
         - name: wait-for-db-to-be-ready
           image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -56,6 +57,7 @@ spec:
                 echo "Waiting for DB ${PGUSER}@${PGHOST}:${PGPORT} to be up";
                 sleep 15;
               done;
+    {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/hapi-fhir-jpaserver/templates/deployment.yaml
+++ b/charts/hapi-fhir-jpaserver/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-    {{ if $.Values.postgresql.enabled }}
+    {{- if $.Values.postgresql.enabled }}
       initContainers:
         - name: wait-for-db-to-be-ready
           image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
@@ -57,7 +57,7 @@ spec:
                 echo "Waiting for DB ${PGUSER}@${PGHOST}:${PGPORT} to be up";
                 sleep 15;
               done;
-    {{ end }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/hapi-fhir-jpaserver/templates/deployment.yaml
+++ b/charts/hapi-fhir-jpaserver/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-    {{- if $.Values.postgresql.enabled }}
+    {{- if .Values.postgresql.enabled }}
       initContainers:
         - name: wait-for-db-to-be-ready
           image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"


### PR DESCRIPTION
Issue #359: Helm deploy with external database is failing due to missing Values.postgresql.image.registry

Solution: The proposed solution that is verified in my environent is to conditionaly call the initContainers only when the .postgresql.enabled is set to true and to ommit if the .postgresql.enabled is set to false