### PR TITLE
bumping to non-snapshot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-	<version>6.1.0-PRE1-SNAPSHOT</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>


### PR DESCRIPTION
Previous HAPI dependency was a SNAPSHOT, this bumps to non-SNAPSHOT version of HAPI (6.0.1).