### PR TITLE
add BinaryAccessProvider to BaseJpaRestfulServer when binary_storage_enabled is true

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BaseJpaRestfulServer.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.binary.interceptor.BinaryStorageInterceptor;
+import ca.uhn.fhir.jpa.binary.provider.BinaryAccessProvider;
 import ca.uhn.fhir.jpa.bulk.export.provider.BulkDataExportProvider;
 import ca.uhn.fhir.jpa.graphql.GraphQLProvider;
 import ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor;
@@ -85,6 +86,8 @@ public class BaseJpaRestfulServer extends RestfulServer {
   ReindexProvider reindexProvider;
   @Autowired
   BinaryStorageInterceptor binaryStorageInterceptor;
+  @Autowired
+  Optional<BinaryAccessProvider> binaryAccessProvider;
   @Autowired
   IPackageInstallerSvc packageInstallerSvc;
   @Autowired
@@ -318,6 +321,7 @@ public class BaseJpaRestfulServer extends RestfulServer {
 
     // Binary Storage
     if (appProperties.getBinary_storage_enabled()) {
+      registerProvider(binaryAccessProvider.get());
       getInterceptorService().registerInterceptor(binaryStorageInterceptor);
     }
 


### PR DESCRIPTION
the problem is described in #385. 

this pull request registering BinaryAccessProvider when binary_storage_enabled is enabled.