### PR TITLE
Mapping table interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+          <groupId>com.googlecode.json-simple</groupId>
+          <artifactId>json-simple</artifactId>
+          <version>1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -40,6 +40,8 @@ import ca.uhn.fhir.jpa.search.StaleSearchDeletingSvcImpl;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.annotations.OnImplementationGuidesPresent;
 import ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationInterceptorFactory;
+import ca.uhn.fhir.jpa.starter.interceptors.PullDataInterceptor;
+import ca.uhn.fhir.jpa.starter.interceptors.PushDataInterceptor;
 import ca.uhn.fhir.jpa.starter.util.EnvironmentHelper;
 import ca.uhn.fhir.jpa.subscription.util.SubscriptionDebugLogInterceptor;
 import ca.uhn.fhir.jpa.util.ResourceCountCache;
@@ -245,7 +247,7 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
-	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, DaoConfig daoConfig, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, LoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc) {
+	public RestfulServer restfulServer(IFhirSystemDao<?, ?> fhirSystemDao, AppProperties appProperties, DaoRegistry daoRegistry, Optional<MdmProviderLoader> mdmProviderProvider, IJpaSystemProvider jpaSystemProvider, ResourceProviderFactory resourceProviderFactory, DaoConfig daoConfig, ISearchParamRegistry searchParamRegistry, IValidationSupport theValidationSupport, DatabaseBackedPagingProvider databaseBackedPagingProvider, LoggingInterceptor loggingInterceptor, Optional<TerminologyUploaderProvider> terminologyUploaderProvider, Optional<SubscriptionTriggeringProvider> subscriptionTriggeringProvider, Optional<CorsInterceptor> corsInterceptor, IInterceptorBroadcaster interceptorBroadcaster, Optional<BinaryAccessProvider> binaryAccessProvider, BinaryStorageInterceptor binaryStorageInterceptor, IValidatorModule validatorModule, Optional<GraphQLProvider> graphQLProvider, BulkDataExportProvider bulkDataExportProvider, BulkDataImportProvider bulkDataImportProvider, ValueSetOperationProvider theValueSetOperationProvider, ReindexProvider reindexProvider, PartitionManagementProvider partitionManagementProvider, Optional<RepositoryValidatingInterceptor> repositoryValidatingInterceptor, IPackageInstallerSvc packageInstallerSvc, PushDataInterceptor pushDataInterceptor, PullDataInterceptor pullDataInterceptor) {
 		RestfulServer fhirServer = new RestfulServer(fhirSystemDao.getContext());
 
 
@@ -417,6 +419,9 @@ public class StarterJpaConfig {
 		repositoryValidatingInterceptor.ifPresent(fhirServer::registerInterceptor);
 
 
+    /* push / pull data interceptor */
+    fhirServer.registerInterceptor(pushDataInterceptor);
+    fhirServer.registerInterceptor(pullDataInterceptor);
 
 		return fhirServer;
 	}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AbortDatabaseOperationException.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AbortDatabaseOperationException.java
@@ -1,0 +1,5 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+public class AbortDatabaseOperationException extends RuntimeException {
+  public AbortDatabaseOperationException() {}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
@@ -1,0 +1,79 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.starter.mappers.IResourceMapper;
+import ca.uhn.fhir.jpa.starter.mappers.ResourceMapperRegistry;
+
+@Component
+@Interceptor
+public class PullDataInterceptor {
+  private String connectionString;
+  private DaoRegistry daoRegistry;
+  private ResourceMapperRegistry mapperRegistry;
+
+  public PullDataInterceptor(@Value("${mappingtable.jdbc}") String connectionString, DaoRegistry daoRegistry, ResourceMapperRegistry mapperRegistry) {
+    this.connectionString = connectionString;
+    this.daoRegistry = daoRegistry;
+    this.mapperRegistry = mapperRegistry;
+  }
+
+  @Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
+  public boolean pullDataBeforeRequest(HttpServletRequest req, HttpServletResponse resp) {
+    String resourceName = req.getContextPath().substring(1);
+    String selectSql = String.format("SELECT * FROM %s;", resourceName);
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      /* 1 Pull mapping table */
+      PreparedStatement stat = conn.prepareStatement(selectSql);
+      ResultSet result = stat.executeQuery();
+
+      /* 2 Update Fhir Database using DAO and Mapper */
+      IFhirResourceDao<IBaseResource> dao = daoRegistry.getResourceDao(resourceName);
+      IResourceMapper mapper = mapperRegistry.getMapper(resourceName);
+      Date latest = null; /* Remember latest timestamp reflected */
+      while (result.next()) {
+        Date timestamp = result.getDate("ts");
+        if (latest == null || latest.before(timestamp)) {
+          latest = timestamp;
+        }
+
+        boolean deleteFlag = result.getBoolean("deleted");
+        IBaseResource resource = mapper.mapToResource(result);
+        if (deleteFlag) {
+          dao.delete(resource.getIdElement());
+        } else {
+          dao.update(resource);
+        }
+      }
+
+      if (req.getMethod().equals(HttpMethod.GET.toString())) {
+        /* 3 Delete Mapping table */
+        String deleteSql = String.format("DELETE FROM %s WHERE ts < ?", resourceName);
+        PreparedStatement deleteStat = conn.prepareStatement(deleteSql);
+        deleteStat.setDate(1, latest);
+        deleteStat.executeUpdate();
+      }
+      return true;
+    } catch (SQLException e) {
+      return false;
+    }
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PullDataInterceptor.java
@@ -39,7 +39,7 @@ public class PullDataInterceptor {
   @Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_PROCESSED)
   public boolean pullDataBeforeRequest(HttpServletRequest req, HttpServletResponse resp) {
     String resourceName = req.getContextPath().substring(1);
-    String selectSql = String.format("SELECT * FROM %s;", resourceName);
+    String selectSql = String.format("SELECT * FROM %s WHERE emr = true;", resourceName);
     try (Connection conn = DriverManager.getConnection(connectionString)) {
       /* 1 Pull mapping table */
       PreparedStatement stat = conn.prepareStatement(selectSql);
@@ -66,7 +66,7 @@ public class PullDataInterceptor {
 
       if (req.getMethod().equals(HttpMethod.GET.toString())) {
         /* 3 Delete Mapping table */
-        String deleteSql = String.format("DELETE FROM %s WHERE ts < ?", resourceName);
+        String deleteSql = String.format("DELETE FROM %s WHERE ts < ? AND emr = true", resourceName);
         PreparedStatement deleteStat = conn.prepareStatement(deleteSql);
         deleteStat.setDate(1, latest);
         deleteStat.executeUpdate();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -1,0 +1,69 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.starter.mappers.DatabaseOperation;
+import ca.uhn.fhir.jpa.starter.mappers.IResourceMapper;
+import ca.uhn.fhir.jpa.starter.mappers.ResourceMapperRegistry;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+
+@Component
+@Interceptor
+public class PushDataInterceptor {
+  private String connectionString;
+  private ResourceMapperRegistry mapperRegistry;
+
+  public PushDataInterceptor(@Value("${mappingtable.jdbc}") String connectionString, ResourceMapperRegistry mapperRegistry) {
+    this.connectionString = connectionString;
+    this.mapperRegistry = mapperRegistry;
+  }
+
+  @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
+  public void pushCreateData(IBaseResource resource, RequestDetails details) {
+    /* Push to mapping table */
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+      String sql = mapper.mapToTable(resource, DatabaseOperation.INSERT);
+      PreparedStatement stat = conn.prepareStatement(sql);
+      stat.executeUpdate();
+    } catch (SQLException e) {
+    }
+    throw new AbortDatabaseOperationException();
+  }
+
+  @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
+  public void pushUpdateData(IBaseResource resource, RequestDetails details) {
+    /* Push to mapping table */
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+      String sql = mapper.mapToTable(resource, DatabaseOperation.UPDATE);
+      PreparedStatement stat = conn.prepareStatement(sql);
+      stat.executeUpdate();
+    } catch (SQLException e) {
+    }
+    throw new AbortDatabaseOperationException();
+  }
+
+  @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_DELETED)
+  public void pushDeleteData(IBaseResource resource, RequestDetails details) {
+    /* Push to mapping table */
+    try (Connection conn = DriverManager.getConnection(connectionString)) {
+      IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+      String sql = mapper.mapToTable(resource, DatabaseOperation.DELETE);
+      PreparedStatement stat = conn.prepareStatement(sql);
+      stat.executeUpdate();
+    } catch (SQLException e) {
+    }
+    throw new AbortDatabaseOperationException();
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PushDataInterceptor.java
@@ -30,7 +30,11 @@ public class PushDataInterceptor {
 
   @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
   public void pushCreateData(IBaseResource resource, RequestDetails details) {
+    IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
+    String sql = mapper.mapToTable(resource, DatabaseOperation.INSERT);
     /* Push to mapping table */
+    /*
+     * 
     try (Connection conn = DriverManager.getConnection(connectionString)) {
       IResourceMapper mapper = mapperRegistry.getMapper(details.getResourceName());
       String sql = mapper.mapToTable(resource, DatabaseOperation.INSERT);
@@ -38,6 +42,8 @@ public class PushDataInterceptor {
       stat.executeUpdate();
     } catch (SQLException e) {
     }
+     */
+    System.out.println(sql);
     throw new AbortDatabaseOperationException();
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/DatabaseOperation.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/DatabaseOperation.java
@@ -1,0 +1,7 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+public enum DatabaseOperation {
+  INSERT,
+  UPDATE,
+  DELETE,
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
@@ -1,0 +1,12 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+public interface IResourceMapper {
+  public String getResourceName();
+  public IBaseResource mapToResource(ResultSet table) throws SQLException;
+  public String mapToTable(IBaseResource resource, DatabaseOperation op);
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/IResourceMapper.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.starter.mappers;
 
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
@@ -7,6 +8,6 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 
 public interface IResourceMapper {
   public String getResourceName();
-  public IBaseResource mapToResource(ResultSet table) throws SQLException;
+  public IBaseResource mapToResource(ResultSet table) throws SQLException, IOException;
   public String mapToTable(IBaseResource resource, DatabaseOperation op);
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -1,0 +1,84 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+import java.io.StringWriter;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonWriter;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r5.model.Patient;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+
+public class PatientResourceMapper implements IResourceMapper {
+  private final FhirContext fhirContext;
+
+  public PatientResourceMapper(DaoRegistry daoRegistry) {
+    this.fhirContext = daoRegistry.getSystemDao().getContext();
+  }
+
+
+  @Override
+  public String getResourceName() {
+    return "Patient";
+  }
+
+  @Override
+  public IBaseResource mapToResource(ResultSet table) throws SQLException {
+    String patientID = table.getString("PatientID");
+    String patientGender = table.getString("PatientGender");
+    String patientDateOfBirth = table.getString("PatientDateOfBirth");
+    String patientRace = table.getString("PatientRace");
+    String patientMaritalStatus = table.getString("PatientMaritalStatus");
+    String patientLanguage = table.getString("PatientLanguage");
+    Double patientPopulationPercentageBelowPoverty = table.getDouble("PatientPopulationPercentageBelowPoverty");
+
+    JsonObject jsonObj = Json.createObjectBuilder()
+        .add("resourceType", "Patient")
+        .add("id", patientID)
+        .add("gender", patientGender)
+        .add("birthDate", patientDateOfBirth.substring(0, 10))
+        .add("maritalStatus", Json.createObjectBuilder().add("text", patientMaritalStatus).build())
+        .add("meta", Json.createObjectBuilder().add("lastUpdated", table.getDate("ts").toString()).build())
+        .build();
+    
+    StringWriter stringWriter = new StringWriter();
+    JsonWriter writer = Json.createWriter(stringWriter);
+    writer.writeObject(jsonObj);
+    writer.close();
+    String fhirText = stringWriter.getBuffer().toString();
+
+    return fhirContext.newJsonParser().parseResource(Patient.class, fhirText);
+  }
+
+  @Override
+  public String mapToTable(IBaseResource resource, DatabaseOperation op) {
+    Patient patient = (Patient) resource;
+    String id = patient.getIdElement() == null ? null : patient.getIdElement().getIdPart();
+    String gender = patient.getGender().getDisplay();
+    String birthDate = patient.getBirthDate().toString();
+    String maritalStatus = patient.getMaritalStatus().getText();
+    String lastUpdated = patient.getMeta().getLastUpdated().toString();
+
+    boolean deleted = op.equals(DatabaseOperation.DELETE);
+
+    if (id == null) {
+      return String.format(
+          "INSERT INTO Patient (PatientGender, PatientDateOfBirth, PatientMaritalStatus) VALUES ('%s', '%s', '%s');",
+          gender, birthDate, maritalStatus);
+    }
+
+    String updateSql = String.format(
+        "UPDATE Patient SET PatientGender = '%s', PatientDateOfBirth = '%s', PatientMaritalStatus = '%s', deleted = %s WHERE PatientID = '%s' AND ts = '%s';", gender, birthDate, maritalStatus, deleted, id, lastUpdated);
+    String insertSql = String.format(
+        "INSERT INTO Patient (PatientID, PatientGender, PatientDateOfBirth, PatientMaritalStatus, deleted) VALUES ('%s', '%s', '%s', '%s', %s);",
+        id, gender, birthDate, maritalStatus, deleted);
+    return String.format(
+        "IF EXISTS (SELECT 1 FROM Patient WHERE PatientID = '%s') BEGIN %s END ELSE BEGIN %s END", id, updateSql, insertSql);
+  }
+  
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/PatientResourceMapper.java
@@ -68,14 +68,14 @@ public class PatientResourceMapper implements IResourceMapper {
 
     if (id == null) {
       return String.format(
-          "INSERT INTO Patient (PatientGender, PatientDateOfBirth, PatientMaritalStatus) VALUES ('%s', '%s', '%s');",
+          "INSERT INTO Patient (PatientGender, PatientDateOfBirth, PatientMaritalStatus, fhir) VALUES ('%s', '%s', '%s', true);",
           gender, birthDate, maritalStatus);
     }
 
     String updateSql = String.format(
-        "UPDATE Patient SET PatientGender = '%s', PatientDateOfBirth = '%s', PatientMaritalStatus = '%s', deleted = %s WHERE PatientID = '%s' AND ts = '%s';", gender, birthDate, maritalStatus, deleted, id, lastUpdated);
+        "UPDATE Patient SET PatientGender = '%s', PatientDateOfBirth = '%s', PatientMaritalStatus = '%s', deleted = %s, fhir = true WHERE PatientID = '%s' AND ts = '%s';", gender, birthDate, maritalStatus, deleted, id, lastUpdated);
     String insertSql = String.format(
-        "INSERT INTO Patient (PatientID, PatientGender, PatientDateOfBirth, PatientMaritalStatus, deleted) VALUES ('%s', '%s', '%s', '%s', %s);",
+        "INSERT INTO Patient (PatientID, PatientGender, PatientDateOfBirth, PatientMaritalStatus, deleted, fhir) VALUES ('%s', '%s', '%s', '%s', %s, true);",
         id, gender, birthDate, maritalStatus, deleted);
     return String.format(
         "IF EXISTS (SELECT 1 FROM Patient WHERE PatientID = '%s') BEGIN %s END ELSE BEGIN %s END", id, updateSql, insertSql);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mappers/ResourceMapperRegistry.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mappers/ResourceMapperRegistry.java
@@ -1,0 +1,31 @@
+package ca.uhn.fhir.jpa.starter.mappers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+
+@Component
+public class ResourceMapperRegistry {
+  Map<String, IResourceMapper> registry;
+  
+  @Autowired
+  public ResourceMapperRegistry(List<IResourceMapper> mappers) {
+    registry = new HashMap<>();
+    mappers.forEach(mapper -> registry.put(mapper.getResourceName(), mapper));
+  }
+
+  public IResourceMapper getMapper(String resourceName) {
+    if (registry.keySet().contains(resourceName)) {
+      return registry.get(resourceName);
+    }
+    throw new InvalidRequestException(
+        Msg.code(572) + "Unable to process request, this server does not know how to handle resources of type "
+            + resourceName + " - Can handle: " + registry.keySet());
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -194,4 +194,6 @@ hapi:
 #  username: SomeUsername
 
 mappingtable:
-  jdbc: postgresql://localhost:5432/poc
+  jdbc: jdbc:postgresql://localhost:5432/poc
+  username: postgres
+  password: admin

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -192,3 +192,6 @@ hapi:
 #  protocol: 'http'
 #  schema_management_strategy: CREATE
 #  username: SomeUsername
+
+mappingtable:
+  jdbc: postgresql://localhost:5432/poc


### PR DESCRIPTION
* Interceptor랑 ResourceMapper registry 구현
* Patient Resource Mapper 샘플 구현
* 돌려보고 싶으면
로컬에 postgres 띄우고 (connection 정보는 application.yaml에서 수정)
```
CREATE TABLE Patient (
  PatientID VARCHAR(50),
  PatientGender VARCHAR(50),
  PatientDateOfBirth VARCHAR(50),
  PatientRace VARCHAR(50),
  PatientMaritalStatus VARCHAR(50),
  PatientLanguage VARCHAR(50),
  PatientPopulationPercentageBelowPoverty decimal,
  deleted BOOLEAN DEFAULT false,
  emr BOOLEAN DEFAULT false,
  fhir BOOLEAN DEFAULT false,
  ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
);

CREATE OR REPLACE FUNCTION update_modified_column()   
RETURNS TRIGGER AS $$
BEGIN
    NEW.ts = now();
    RETURN NEW;   
END;
$$ language 'plpgsql';

CREATE TRIGGER update_modtime BEFORE UPDATE ON Patient FOR EACH ROW EXECUTE PROCEDURE  update_modified_column();
```
이렇게 해놓고 EMR에서 넣듯이 넣거나 CUD에 해당하는 POST요청 실행(?)
