### PR TITLE
Proper close DB connection after dialect was resolved

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/util/JpaHibernatePropertiesProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/util/JpaHibernatePropertiesProvider.java
@@ -8,6 +8,8 @@ import org.hibernate.engine.jdbc.dialect.spi.DatabaseMetaDataDialectResolutionIn
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 
 import javax.sql.DataSource;
+
+import java.sql.Connection;
 import java.sql.SQLException;
 
 public class JpaHibernatePropertiesProvider extends HibernatePropertiesProvider {
@@ -16,9 +18,9 @@ public class JpaHibernatePropertiesProvider extends HibernatePropertiesProvider 
 
   public JpaHibernatePropertiesProvider(LocalContainerEntityManagerFactoryBean myEntityManagerFactory) {
     DataSource connection = myEntityManagerFactory.getDataSource();
-    try {
+    try ( Connection dbConnection = connection.getConnection()){
       dialect = new StandardDialectResolver()
-        .resolveDialect(new DatabaseMetaDataDialectResolutionInfoAdapter(connection.getConnection().getMetaData()));
+        .resolveDialect(new DatabaseMetaDataDialectResolutionInfoAdapter(dbConnection.getMetaData()));
     } catch (SQLException sqlException) {
       throw new ConfigurationException(sqlException.getMessage(), sqlException);
     }


### PR DESCRIPTION
Currently sonar mark connection.getConnection() as resource leak, since the connection is never closed after dialect has been resolved.  Simply use try-with-resources to ensure connection is closed after usage.