### PR TITLE
fixed SubscriptionDebugLogInterceptor adding logic

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -346,7 +346,7 @@ public class StarterJpaConfig {
 
 		corsInterceptor.ifPresent(fhirServer::registerInterceptor);
 
-		if (appProperties.getSubscription() != null) {
+		if (daoConfig.getSupportedSubscriptionTypes().size() > 0) {
 			// Subscription debug logging
 			fhirServer.registerInterceptor(new SubscriptionDebugLogInterceptor());
 		}


### PR DESCRIPTION
SubscriptionDebugLogInterceptor() is only registered if `daoConfig.getSupportedSubscriptionTypes().size() > 0`
fixes: #441