### PR TITLE
Update pom.xml to reference hapi-fhir 6.3.4-SNAPSHOT.  This hapi-fhir release contains a fix for POSTing an XML resource with comments results in a fhir_comments error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>6.2.2</version>
+        <version>6.3.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
@@ -44,12 +44,12 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-api</artifactId>
+            <artifactId>websocket-jetty-api</artifactId>
             <version>${jetty_version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-client</artifactId>
+            <artifactId>websocket-jetty-client</artifactId>
             <version>${jetty_version}</version>
         </dependency>
         <dependency>
@@ -246,7 +246,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
+            <artifactId>websocket-jetty-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- hapi-fhir 6.3.4-SNAPSHOT contains a fix for a fhir-comments error when POSTing XML resources with comments
- Upgrading required pointing to websocket-jetty dependencies that had been renamed since 6.2.2, for example 

TODO:  create a new issue to cover this