### PR TITLE
Remove old junit4 usage.

### DIFF
--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
@@ -15,7 +15,6 @@ import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.instance.model.api.IIdType;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 
 import static ca.uhn.fhir.util.TestUtil.waitForSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties =
@@ -112,11 +113,11 @@ public class ExampleServerDstu3IT implements IServerSupport {
       .execute();
 
     List<Parameters.ParametersParameterComponent> response = outParams.getParameter();
-	  Assert.assertFalse(response.isEmpty());
+	  assertFalse(response.isEmpty());
     Parameters.ParametersParameterComponent component = response.get(0);
-    Assert.assertTrue(component.getResource() instanceof MeasureReport);
+    assertTrue(component.getResource() instanceof MeasureReport);
     MeasureReport report = (MeasureReport) component.getResource();
-    Assert.assertEquals("Measure/"+measureId, report.getMeasure());
+    assertEquals("Measure/"+measureId, report.getMeasure());
   }
 
   private int loadDataFromDirectory(String theDirectoryName) throws IOException {


### PR DESCRIPTION
Testcontainers sadly needs junit4. Thus some junit4 api usage appears to have crept in.

This pull request contains a tiny clean up, removing those few calls.

P.S.: I tried excluding junit4 in the pom but that does not work because testcontainers actually needs junit4 to work.

Hope this is helpful.