### PR TITLE
Revert "Update pom.xml to reference hapi-fhir 6.3.6-SNAPSHOT.  This hapi-fhir release contains a fix for POSTing an XML resource with comments results in a fhir_comments error"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>6.3.6-SNAPSHOT</version>
+        <version>6.2.2</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
@@ -44,12 +44,12 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jetty-api</artifactId>
+            <artifactId>websocket-api</artifactId>
             <version>${jetty_version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jetty-client</artifactId>
+            <artifactId>websocket-client</artifactId>
             <version>${jetty_version}</version>
         </dependency>
         <dependency>
@@ -150,19 +150,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <!-- Please note that in the process of upgrading from hapi-fhir 6.22 to 6.3.4-SNAPSHOT logback was upgraded from 1.2.10. to 1.4.4.  This included the removal of the StaticLoggerBinder class. -->
-            <!-- In order to resolve this error, the only solution we found was to explicitly use version 1.2.10.  However, this exposes a Spring dependency issue with the hapi-fhir-jpaserver-base module and JpaConfig method memberMatcherR4Helper(). -->
-            <version>1.2.10</version>
         </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <!-- Please note that in the process of upgrading from hapi-fhir 6.22 to 6.3.4-SNAPSHOT logback was upgraded from 1.2.10. to 1.4.4.  This included the removal of the StaticLoggerBinder class. -->
-            <!-- In order to resolve this error, the only solution we found was to explicitly use version 1.2.10.  However, this exposes a Spring dependency issue with the hapi-fhir-jpaserver-base module and JpaConfig method memberMatcherR4Helper(). -->
-            <version>1.2.10</version>
-        </dependency>
-
 
         <!-- Needed for JEE/Servlet support -->
         <dependency>
@@ -258,7 +246,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jetty-server</artifactId>
+            <artifactId>websocket-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigDstu2.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigDstu2.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.starter.common;
 
 import ca.uhn.fhir.jpa.config.JpaDstu2Config;
 import ca.uhn.fhir.jpa.starter.annotations.OnDSTU2Condition;
+import ca.uhn.fhir.jpa.term.TermCodeSystemStorageSvcImpl;
 import ca.uhn.fhir.jpa.term.TermLoaderSvcImpl;
 import ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc;
 import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
@@ -21,6 +22,11 @@ public class FhirServerConfigDstu2 {
 	@Bean
 	public ITermLoaderSvc termLoaderService(ITermDeferredStorageSvc theDeferredStorageSvc, ITermCodeSystemStorageSvc theCodeSystemStorageSvc) {
 		return new TermLoaderSvcImpl(theDeferredStorageSvc, theCodeSystemStorageSvc);
+	}
+
+	@Bean
+	public ITermCodeSystemStorageSvc termCodeSystemStorageSvc() {
+		return new TermCodeSystemStorageSvcImpl();
 	}
 
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -207,6 +207,16 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
+	@Primary
+	/*
+		This bean is currently necessary to override from MDM settings
+	 */
+	IMdmLinkDao mdmLinkDao() {
+		return new MdmLinkDaoJpaImpl();
+	}
+
+
+	@Bean
 	@Conditional(OnCorsPresent.class)
 	public CorsInterceptor corsInterceptor(AppProperties appProperties) {
 		// Define your CORS configuration. This is an example

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 	"hapi.fhir.fhir_version=r4b",
 	"hapi.fhir.subscription.websocket_enabled=false",
 	"hapi.fhir.mdm_enabled=false",
+	"hapi.fhir.implementationguides.dk-core.name=hl7.fhir.dk.core",
+	"hapi.fhir.implementationguides.dk-core.version=1.1.0",
 	// Override is currently required when using MDM as the construction of the MDM
 	// beans are ambiguous as they are constructed multiple places. This is evident
 	// when running in a spring boot environment


### PR DESCRIPTION
This is needed because the changes in question have disabled logging entirely in jpa-serverstarter.

Closes [477](https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/477)

Reverts hapifhir/hapi-fhir-jpaserver-starter#465