### PR TITLE
Upgrade to hapi-fhir 6.3.6-SNAPSHOT:  Alternative solution.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>6.2.2</version>
+        <version>6.3.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
@@ -44,12 +44,12 @@
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-api</artifactId>
+            <artifactId>websocket-jetty-api</artifactId>
             <version>${jetty_version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-client</artifactId>
+            <artifactId>websocket-jetty-client</artifactId>
             <version>${jetty_version}</version>
         </dependency>
         <dependency>
@@ -246,7 +246,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
+            <artifactId>websocket-jetty-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
 
     <properties>
         <java.version>11</java.version>
+        <logback-classic.version>1.2.11</logback-classic.version>
+        <slf4j-api.version>1.7.25</slf4j-api.version>
     </properties>
 
     <prerequisites>
@@ -355,6 +357,23 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <version>${spring_boot_version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j-api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-classic.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback-classic.version}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -38,6 +38,10 @@ import org.springframework.web.servlet.DispatcherServlet;
 })
 public class Application extends SpringBootServletInitializer {
 
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
+
   public static void main(String[] args) {
 
     SpringApplication.run(Application.class, args);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -38,10 +38,6 @@ import org.springframework.web.servlet.DispatcherServlet;
 })
 public class Application extends SpringBootServletInitializer {
 
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
   public static void main(String[] args) {
 
     SpringApplication.run(Application.class, args);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigDstu2.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigDstu2.java
@@ -2,7 +2,6 @@ package ca.uhn.fhir.jpa.starter.common;
 
 import ca.uhn.fhir.jpa.config.JpaDstu2Config;
 import ca.uhn.fhir.jpa.starter.annotations.OnDSTU2Condition;
-import ca.uhn.fhir.jpa.term.TermCodeSystemStorageSvcImpl;
 import ca.uhn.fhir.jpa.term.TermLoaderSvcImpl;
 import ca.uhn.fhir.jpa.term.api.ITermCodeSystemStorageSvc;
 import ca.uhn.fhir.jpa.term.api.ITermDeferredStorageSvc;
@@ -22,11 +21,6 @@ public class FhirServerConfigDstu2 {
 	@Bean
 	public ITermLoaderSvc termLoaderService(ITermDeferredStorageSvc theDeferredStorageSvc, ITermCodeSystemStorageSvc theCodeSystemStorageSvc) {
 		return new TermLoaderSvcImpl(theDeferredStorageSvc, theCodeSystemStorageSvc);
-	}
-
-	@Bean
-	public ITermCodeSystemStorageSvc termCodeSystemStorageSvc() {
-		return new TermCodeSystemStorageSvcImpl();
 	}
 
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -207,16 +207,6 @@ public class StarterJpaConfig {
 	}
 
 	@Bean
-	@Primary
-	/*
-		This bean is currently necessary to override from MDM settings
-	 */
-	IMdmLinkDao mdmLinkDao() {
-		return new MdmLinkDaoJpaImpl();
-	}
-
-
-	@Bean
 	@Conditional(OnCorsPresent.class)
 	public CorsInterceptor corsInterceptor(AppProperties appProperties) {
 		// Define your CORS configuration. This is an example

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CustomBeanTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CustomBeanTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties = {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties = {
 		"hapi.fhir.custom-bean-packages=some.custom.pkg1,some.custom.pkg2",
 		"spring.datasource.url=jdbc:h2:mem:dbr4",
 		// "hapi.fhir.enable_repository_validating_interceptor=true",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CustomBeanTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CustomBeanTest.java
@@ -13,10 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 })
 public class CustomBeanTest {
 
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
 	@Autowired
 	some.custom.pkg1.CustomBean customBean1;
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CustomBeanTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CustomBeanTest.java
@@ -13,6 +13,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 })
 public class CustomBeanTest {
 
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
+
 	@Autowired
 	some.custom.pkg1.CustomBean customBean1;
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CustomInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CustomInterceptorTest.java
@@ -13,7 +13,7 @@ import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties = {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties = {
 		"hapi.fhir.custom-bean-packages=some.custom.pkg1",
 		"hapi.fhir.custom-interceptor-classes=some.custom.pkg1.CustomInterceptorBean,some.custom.pkg1.CustomInterceptorPojo",
 		"spring.datasource.url=jdbc:h2:mem:dbr4",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CustomInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CustomInterceptorTest.java
@@ -23,6 +23,10 @@ import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 
 public class CustomInterceptorTest {
 
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
+
 	@LocalServerPort
 	private int port;
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CustomInterceptorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CustomInterceptorTest.java
@@ -23,10 +23,6 @@ import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 
 public class CustomInterceptorTest {
 
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
 	@LocalServerPort
 	private int port;
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
@@ -57,8 +57,12 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
   })
 @ContextConfiguration(initializers = ElasticsearchLastNR4IT.Initializer.class)
 public class ElasticsearchLastNR4IT {
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
 
-  private IGenericClient ourClient;
+
+	private IGenericClient ourClient;
   private FhirContext ourCtx;
 
   private static final String ELASTIC_VERSION = "7.16.3";

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
@@ -57,10 +57,6 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
   })
 @ContextConfiguration(initializers = ElasticsearchLastNR4IT.Initializer.class)
 public class ElasticsearchLastNR4IT {
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
 
 	private IGenericClient ourClient;
   private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties =
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties =
   {
     "spring.datasource.url=jdbc:h2:mem:dbr4",
     "hapi.fhir.fhir_version=r4",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu2IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu2IT.java
@@ -16,7 +16,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties =
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties =
   {
      "hapi.fhir.fhir_version=dstu2",
      "spring.datasource.url=jdbc:h2:mem:dbr2",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu2IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu2IT.java
@@ -23,10 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
   })
 public class ExampleServerDstu2IT {
 
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
 	private IGenericClient ourClient;
 	private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu2IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu2IT.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
   })
 public class ExampleServerDstu2IT {
 
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
+
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
 	private IGenericClient ourClient;
 	private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties =
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties =
   {
      "spring.datasource.url=jdbc:h2:mem:dbr3",
      "hapi.fhir.cql_enabled=true",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
@@ -51,10 +51,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExampleServerDstu3IT implements IServerSupport {
 
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
   private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
   private IGenericClient ourClient;
   private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerDstu3IT.java
@@ -51,6 +51,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExampleServerDstu3IT implements IServerSupport {
 
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
+
   private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
   private IGenericClient ourClient;
   private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
@@ -14,7 +14,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties = {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties = {
 	"spring.datasource.url=jdbc:h2:mem:dbr4b",
 	"hapi.fhir.enable_repository_validating_interceptor=true",
 	"hapi.fhir.fhir_version=r4b",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
@@ -20,13 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 	"hapi.fhir.fhir_version=r4b",
 	"hapi.fhir.subscription.websocket_enabled=false",
 	"hapi.fhir.mdm_enabled=false",
-	"hapi.fhir.implementationguides.dk-core.name=hl7.fhir.dk.core",
-	"hapi.fhir.implementationguides.dk-core.version=1.1.0",
 	// Override is currently required when using MDM as the construction of the MDM
 	// beans are ambiguous as they are constructed multiple places. This is evident
 	// when running in a spring boot environment
 	"spring.main.allow-bean-definition-overriding=true"})
 class ExampleServerR4BIT {
+
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerR4BIT.class);
 	private IGenericClient ourClient;
 	private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4BIT.java
@@ -25,10 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 	// when running in a spring boot environment
 	"spring.main.allow-bean-definition-overriding=true"})
 class ExampleServerR4BIT {
-
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerR4BIT.class);
 	private IGenericClient ourClient;
 	private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4IT.java
@@ -30,7 +30,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties = {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties = {
 		"spring.datasource.url=jdbc:h2:mem:dbr4",
 		"hapi.fhir.enable_repository_validating_interceptor=true",
 		"hapi.fhir.fhir_version=r4",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4IT.java
@@ -43,6 +43,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 		// when running in a spring boot environment
 		"spring.main.allow-bean-definition-overriding=true" })
 class ExampleServerR4IT {
+
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
+
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerR4IT.class);
 	private IGenericClient ourClient;
 	private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR4IT.java
@@ -43,11 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 		// when running in a spring boot environment
 		"spring.main.allow-bean-definition-overriding=true" })
 class ExampleServerR4IT {
-
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerR4IT.class);
 	private IGenericClient ourClient;
 	private FhirContext ourCtx;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR5IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR5IT.java
@@ -32,7 +32,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties =
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties =
   {
      "spring.datasource.url=jdbc:h2:mem:dbr5",
      "hapi.fhir.fhir_version=r5",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR5IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR5IT.java
@@ -41,7 +41,11 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
   })
 public class ExampleServerR5IT {
 
-  private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
+
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
   private IGenericClient ourClient;
   private FhirContext ourCtx;
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR5IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ExampleServerR5IT.java
@@ -41,11 +41,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
   })
 public class ExampleServerR5IT {
 
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
-
-	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
+  private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
   private IGenericClient ourClient;
   private FhirContext ourCtx;
 

--- a/src/test/java/ca/uhn/fhir/jpa/starter/JpaStarterWebsocketDispatcherConfig.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/JpaStarterWebsocketDispatcherConfig.java
@@ -1,0 +1,34 @@
+package ca.uhn.fhir.jpa.starter;
+
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.websocket.server.config.JettyWebSocketServletContainerInitializer;
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This class ensures that websockets work with
+ * Spring + Spring Boot + Jetty
+ */
+@Configuration
+public class JpaStarterWebsocketDispatcherConfig {
+
+	@Bean
+	public Jetty10WebSocketServletWebServerCustomizer jetty10WebSocketServletWebServerCustomizer() {
+		return new Jetty10WebSocketServletWebServerCustomizer();
+	}
+
+	static class Jetty10WebSocketServletWebServerCustomizer implements WebServerFactoryCustomizer<JettyServletWebServerFactory> {
+
+		@Override
+		public void customize(JettyServletWebServerFactory factory) {
+
+			factory.addServerCustomizers(server -> {
+				WebAppContext ctx = (WebAppContext) server.getHandler();
+				JettyWebSocketServletContainerInitializer.configure(ctx, null);
+			});
+
+		}
+	}
+}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantServerR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantServerR4IT.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Application.class, properties =
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, JpaStarterWebsocketDispatcherConfig.class}, properties =
   {
     "spring.datasource.url=jdbc:h2:mem:dbr4-mt",
     "hapi.fhir.fhir_version=r4",

--- a/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantServerR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantServerR4IT.java
@@ -28,9 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
   })
 public class MultitenantServerR4IT {
 
-	static {
-		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-	}
 
   private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
   private IGenericClient ourClient;

--- a/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantServerR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantServerR4IT.java
@@ -28,6 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
   })
 public class MultitenantServerR4IT {
 
+	static {
+		System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
+	}
 
   private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ExampleServerDstu2IT.class);
   private IGenericClient ourClient;


### PR DESCRIPTION
- Spawned from the crude and messy but effective solution in [480](https://github.com/hapifhir/hapi-fhir-jpaserver-starter/pull/480)
- Remove static code blocks to Application.java and all tests:
- Downgrade logback.core to 1.2.11
- Downgrade logback.classic to 1.2.11
- Downgrade slf4j-api to 1.7.25 >>>>> This is the key difference missing from the first attempt that disabled logging.
- Add a new test config:  JpaStarterWebsocketDispatcherConfig, and add it to @SpringBootTest for all of the ITs:   This solves the NPE on jetty websocket tests that was introduced by the above changes. >>>> Jetty10RequestUpgradeStrategy.upgrade(Jetty10RequestUpgradeStrategy.java:124). >>> Cannot invoke "Object.getClass()" because "obj" is null