### PR TITLE
docs: Updated README.md. Discontinue mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,35 +177,11 @@ Server will then be accessible at http://localhost:8080/ and eg. http://localhos
 
 Much of this HAPI starter project can be configured using the yaml file in _src/main/resources/application.yaml_. By default, this starter project is configured to use H2 as the database.
 
-### MySql configuration
+### MySQL configuration
 
-To configure the starter app to use MySQL, instead of the default H2, update the application.yaml file to have the following:
+HAPI FHIR JPA Server does not support MySQL as it is deprecated.
 
-```yaml
-spring:
-  datasource:
-    url: 'jdbc:mysql://localhost:3306/hapi_dstu3'
-    username: admin
-    password: admin
-    driverClassName: com.mysql.jdbc.Driver
-```
-
-Also, make sure you are not setting the Hibernate dialect explicitly, in other words remove any lines similar to:
-
-```
-hibernate.dialect: {some none MySQL dialect}
-```
-
-On some systems, it might be necessary to override hibernate's default naming strategy. The naming strategy must be set using spring.jpa.hibernate.physical_naming_strategy.
-
-```yaml
-spring:
-  jpa:
-    hibernate.physical_naming_strategy: NAME_OF_PREFERRED_STRATEGY
-```
-On linux systems or when using docker mysql containers, it will be necessary to review the case-sensitive setup for
-mysql schema identifiers. See  https://dev.mysql.com/doc/refman/8.0/en/identifier-case-sensitivity.html. We suggest you
-set `lower_case_table_names=1` during mysql startup.
+See more at https://hapifhir.io/hapi-fhir/docs/server_jpa/database_support.html
 
 ### PostgreSQL configuration
 
@@ -214,7 +190,7 @@ To configure the starter app to use PostgreSQL, instead of the default H2, updat
 ```yaml
 spring:
   datasource:
-    url: 'jdbc:postgresql://localhost:5432/hapi_dstu3'
+    url: 'jdbc:postgresql://localhost:5432/hapi'
     username: admin
     password: admin
     driverClassName: org.postgresql.Driver
@@ -313,19 +289,20 @@ reached at http://localhost:8080/.
 In order to use another port, change the `ports` parameter
 inside `docker-compose.yml` to `8888:8080`, where 8888 is a port of your choice.
 
-The docker compose set also includes my MySQL database, if you choose to use MySQL instead of H2, change the following
-properties in application.yaml:
+The docker compose set also includes my PoPostgreSQL database, if you choose to use PostgreSQL instead of H2, change the following
+properties in `src/main/resources/application.yaml`:
 
 ```yaml
 spring:
   datasource:
-    url: 'jdbc:mysql://hapi-fhir-mysql:3306/hapi'
+    url: 'jdbc:postgresql://hapi-fhir-postgres:5432/hapi'
     username: admin
     password: admin
-    driverClassName: com.mysql.jdbc.Driver
+    driverClassName: org.postgresql.Driver
+jpa:
+  properties:
+    hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
 ```
-
-Also, make sure you are not setting the Hibernate Dialect explicitly, see more details in the section about MySQL.
 
 ## Running hapi-fhir-jpaserver directly from IntelliJ as Spring Boot
 Make sure you run with the maven profile called ```boot``` and NOT also ```jetty```. Then you are ready to press debug the project directly without any extra Application Servers.
@@ -361,8 +338,6 @@ Run the configuration.
 - Wait for the console output to stop
 
 Point your browser (or fiddler, or what have you) to `http://localhost:8080/hapi/baseDstu3/Patient`
-
-It is important to use MySQL5Dialect when using MySQL version 5+.
 
 ## Enabling Subscriptions
 


### PR DESCRIPTION
Updates `README.md` file to inform that MySQL has been deprecated from HAPI FHIR JPA Server

From MR: https://github.com/hapifhir/hapi-fhir-jpaserver-starter/pull/444