### PR TITLE
removed mysql-connector-java dependency since no longer supported and…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,6 @@
             <version>${jetty_version}</version>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>


### PR DESCRIPTION
… due to CVE-2022-3171 in transitive dependency on protobuf-java-3.19.4

MySQL is no longer supported in HAPI, and it has a transitive dependency on protobuf-java-3.19.4 which has an open CVE. 

NOTE: not certain if this is the same reason for this flag in the base HAPI project: 
https://github.com/hapifhir/hapi-fhir/issues/4373