### PR TITLE
Bump HAPI to 6.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>6.3.13-SNAPSHOT</version>
+        <version>6.4.0</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Application.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.thymeleaf.ThymeleafAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
@@ -26,7 +27,7 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
 import org.springframework.web.servlet.DispatcherServlet;
 
 @ServletComponentScan(basePackageClasses = {RestfulServer.class})
-@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class, ThymeleafAutoConfiguration.class})
 @Import({
 	SubscriptionSubmitterConfig.class,
 	SubscriptionProcessorConfig.class,

--- a/src/test/smoketest/http-client.env.json
+++ b/src/test/smoketest/http-client.env.json
@@ -3,5 +3,10 @@
     "host": "localhost:8080",
     "username": "username",
     "password": "password"
+  },
+  "explicit-ip": {
+    "host": "0.0.0.0:8080",
+    "username": "username",
+    "password": "password"
   }
 }

--- a/src/test/smoketest/http-client.env.json
+++ b/src/test/smoketest/http-client.env.json
@@ -3,10 +3,5 @@
     "host": "localhost:8080",
     "username": "username",
     "password": "password"
-  },
-  "explicit-ip": {
-    "host": "0.0.0.0:8080",
-    "username": "username",
-    "password": "password"
   }
 }


### PR DESCRIPTION
Bumps HAPI to 6.4.0 and fixes a resultant Application configuration issue.

Fixes this error anywhere ca.uhn.fhir.jpa.starter.Application was instantiated:

```log
Parameter 0 of method templateEngine in ca.uhn.fhir.to.FhirTesterMvcConfig required a single bean, but 2 were found:
	- templateResolver: defined by method 'templateResolver' in class path resource [ca/uhn/fhir/to/FhirTesterMvcConfig.class]
	- defaultTemplateResolver: defined by method 'defaultTemplateResolver' in class path resource [org/springframework/boot/autoconfigure/thymeleaf/ThymeleafAutoConfiguration$DefaultTemplateResolverConfiguration.class]
```