### PR TITLE
History count fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=build-hapi --chown=1001:1001 /tmp/hapi-fhir-jpaserver-starter/opente
 ENV ALLOW_EMPTY_PASSWORD=yes
 
 ########### distroless brings focus on security and runs on plain spring boot - this is the default image
-FROM gcr.io/distroless/java17-debian11:nonroot as default
+FROM gcr.io/distroless/java17-debian11:nonroot-arm64 as default
 # 65532 is the nonroot user's uid
 # used here instead of the name to allow Kubernetes to easily detect that the container
 # is running as a non-root (uid != 0) user.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --from=build-hapi --chown=1001:1001 /tmp/hapi-fhir-jpaserver-starter/opente
 ENV ALLOW_EMPTY_PASSWORD=yes
 
 ########### distroless brings focus on security and runs on plain spring boot - this is the default image
-FROM gcr.io/distroless/java17-debian11:nonroot-arm64 as default
+FROM gcr.io/distroless/java17-debian11:nonroot as default
 # 65532 is the nonroot user's uid
 # used here instead of the name to allow Kubernetes to easily detect that the container
 # is running as a non-root (uid != 0) user.

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -63,6 +63,7 @@ public class AppProperties {
   private List<String> supported_resource_types = new ArrayList<>();
   private List<Bundle.BundleType> allowed_bundle_types = null;
   private Boolean narrative_enabled = true;
+  private Integer history_count_mode = 0;
 
   private Validation validation = new Validation();
   private Map<String, Tester> tester = null;
@@ -512,6 +513,16 @@ public class AppProperties {
   public void setNarrative_enabled(Boolean narrative_enabled)
   {
     this.narrative_enabled = narrative_enabled;
+  }
+
+  public Boolean getHistory_count_mode()
+  {
+    return history_count_mode;
+  }
+
+  public Boolean setHistory_count_mode(Integer history_count_mode)
+  {
+    this.history_count_mode = history_count_mode;
   }
 
   public Boolean getLastn_enabled() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -515,12 +515,12 @@ public class AppProperties {
     this.narrative_enabled = narrative_enabled;
   }
 
-  public Boolean getHistory_count_mode()
+  public Integer getHistory_count_mode()
   {
     return history_count_mode;
   }
 
-  public Boolean setHistory_count_mode(Integer history_count_mode)
+  public void setHistory_count_mode(Integer history_count_mode)
   {
     this.history_count_mode = history_count_mode;
   }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -15,6 +15,7 @@ import ca.uhn.fhir.jpa.api.config.DaoConfig;
 import ca.uhn.fhir.jpa.api.config.ThreadPoolFactoryConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
+import ca.uhn.fhir.jpa.api.model.HistoryCountModeEnum;
 import ca.uhn.fhir.jpa.binary.interceptor.BinaryStorageInterceptor;
 import ca.uhn.fhir.jpa.binary.provider.BinaryAccessProvider;
 import ca.uhn.fhir.jpa.bulk.export.provider.BulkDataExportProvider;
@@ -415,6 +416,18 @@ public class StarterJpaConfig {
 		if (!theIpsOperationProvider.isEmpty()) {
 			fhirServer.registerProvider(theIpsOperationProvider.get());
 		}
+
+		// set history_count_mode
+		switch (appProperties.getHistory_count_mode()) {
+			// Ignore case 0 since default is HistoryCountModeEnum.CACHED_ONLY_WITHOUT_OFFSET
+			case 1: {
+				daoConfig.setHistoryCountMode(HistoryCountModeEnum.COUNT_ACCURATE);
+			}
+			case 2: {
+				daoConfig.setHistoryCountMode(HistoryCountModeEnum.COUNT_DISABLED);
+			}
+		}
+
 
 		return fhirServer;
 	}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -131,6 +131,11 @@ hapi:
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
       allowed_origin:
         - '*'
+    # history_count_mode is an integer that represents the mode that the DAOConfig will use when getting the history count during a history request
+      # history_count_mode = 0 -> CACHED_ONLY_WITHOUT_OFFSET (default within hapi-fhir DAOConfig)
+      # history_count_mode = 1 -> COUNT_ACCURATE (ignores cache and always gets correct count)
+      # history_count_mode = 2 -> COUNT_DISABLED (does not return count at all)
+    history_count_mode: 1
 
     # Search coordinator thread pool sizes
     search-coord-core-pool-size: 20

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -114,6 +114,11 @@ hapi:
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
     #  allowed_origin:
     #    - '*'
+    # history_count_mode is an integer that represents the mode that the DAO config will use when getting the history count during a history request
+      # history_count_mode = 0 -> CACHED_ONLY_WITHOUT_OFFSET (default within hapi-fhir DAOConfig)
+      # history_count_mode = 1 -> COUNT_ACCURATE (ignores cache and always gets correct count)
+      # history_count_mode = 2 -> COUNT_DISABLED (does not return count at all)
+    history_count_mode: 1
 
     # Search coordinator thread pool sizes
     search-coord-core-pool-size: 20

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -114,11 +114,11 @@ hapi:
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
     #  allowed_origin:
     #    - '*'
-    # history_count_mode is an integer that represents the mode that the DAO config will use when getting the history count during a history request
+    # history_count_mode is an integer that represents the mode that the DAOConfig will use when getting the history count during a history request
       # history_count_mode = 0 -> CACHED_ONLY_WITHOUT_OFFSET (default within hapi-fhir DAOConfig)
       # history_count_mode = 1 -> COUNT_ACCURATE (ignores cache and always gets correct count)
       # history_count_mode = 2 -> COUNT_DISABLED (does not return count at all)
-    history_count_mode: 1
+    #    history_count_mode: 0
 
     # Search coordinator thread pool sizes
     search-coord-core-pool-size: 20


### PR DESCRIPTION
Resolves this issue https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/433

During integration testing, it is useful to make rapid search history queries, but unless this flag can be configured we are forced to use the default of waiting 1 minute for the history cache to clear. Instead, during integration test we should always be getting the actual data from the db.