### PR TITLE
configuration option to not reload IG resources that are already loaded

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -71,6 +71,7 @@ public class AppProperties {
   private Cors cors = null;
   private Partitioning partitioning = null;
   private Boolean install_transitive_ig_dependencies = true;
+  private Boolean reload_existing_implementationguides = false;
   private Map<String, ImplementationGuide> implementationGuides = null;
 
 	private String staticLocation = null;
@@ -541,9 +542,17 @@ public class AppProperties {
 	public boolean getInstall_transitive_ig_dependencies() {
 		return install_transitive_ig_dependencies;
 	}
-
+	
 	public void setInstall_transitive_ig_dependencies(boolean install_transitive_ig_dependencies) {
 		this.install_transitive_ig_dependencies = install_transitive_ig_dependencies;
+	}
+	
+	public boolean getReload_existing_implementationguides() {
+		return reload_existing_implementationguides;
+	}
+	
+	public void setReload_existing_implementationguides(boolean reload_existing_implementationguides) {
+		this.reload_existing_implementationguides = reload_existing_implementationguides;
 	}
 
 	public Integer getBundle_batch_pool_size() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -198,6 +198,7 @@ public class StarterJpaConfig {
 			Map<String, AppProperties.ImplementationGuide> guides = appProperties.getImplementationGuides();
 			for (Map.Entry<String, AppProperties.ImplementationGuide> guide : guides.entrySet()) {
 				PackageInstallationSpec packageInstallationSpec = new PackageInstallationSpec().setPackageUrl(guide.getValue().getUrl()).setName(guide.getValue().getName()).setVersion(guide.getValue().getVersion()).setInstallMode(PackageInstallationSpec.InstallModeEnum.STORE_AND_INSTALL);
+				packageInstallationSpec.setReloadExisting(appProperties.getReload_existing_implementationguides());
 				if (appProperties.getInstall_transitive_ig_dependencies()) {
 					packageInstallationSpec.setFetchDependencies(true);
 					packageInstallationSpec.setDependencyExcludes(ImmutableList.of("hl7.fhir.r2.core", "hl7.fhir.r3.core", "hl7.fhir.r4.core", "hl7.fhir.r5.core"));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -71,6 +71,8 @@ hapi:
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
+    ### tells the server whether to attempt to load IG resources that are already present
+    #    reload_existing_implementationGuides : false
     #    implementationguides:
     ###    example from registry (packages.fhir.org)
     #      swiss:


### PR DESCRIPTION
update to add config option to skip re-loading/re-indexing IG resources that already exist. (defaults to skip)
see:  https://github.com/hapifhir/hapi-fhir/pull/3989
