### PR TITLE
Simplify using an interceptor with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ WORKDIR /app
 COPY --chown=nonroot:nonroot --from=build-distroless /app /app
 COPY --chown=nonroot:nonroot --from=build-hapi /tmp/hapi-fhir-jpaserver-starter/opentelemetry-javaagent.jar /app
 
-CMD ["/app/main.war"]
+ENTRYPOINT ["java", "--class-path", "/app/main.war", "-Dloader.path=main.war!/WEB-INF/classes/,main.war!/WEB-INF/,/app/extra-classes", "org.springframework.boot.loader.PropertiesLauncher", "app/main.war"]


### PR DESCRIPTION
Now it is possible to mount a folder with extra classes that are loaded by HAPI. This makes it easy to load an interceptor JAR while using the standard Docker image. The README explains how to use it.

Spring by default uses the WarLauncher. Now the ENTRYPOINT uses the PropertiesLauncher, configured in such a way that it is compatible with the WarLauncher, but adding the folder /app/extra-classes to the loader.path.