### PR TITLE
Remove explicit inclusion of snakeyaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-server-openapi</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- This dependency is used for the "FHIR Tester" web app overlay -->
         <dependency>
@@ -167,13 +173,6 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-        </dependency>
-
-        <!-- Needed for parsing the config -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.31</version>
         </dependency>
 
         <!-- Used for CORS support -->


### PR DESCRIPTION

Removed explicit inclusion of snakeyaml due to numerous dependabot security warnings and allow spring-boot-start-actuator to pull it in as a needed dependency.
