### PR TITLE
Use docker for HTTP client

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Start server with jetty
       run: |
         mvn jetty:run & export JPA_PROCESS=$!
-        sleep 60
+        sleep 80
     - name: Execute smoke tests
       run: docker run --rm -v $PWD:/workdir jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -35,6 +35,6 @@ jobs:
         mvn jetty:run & export JPA_PROCESS=$!
         sleep 60
     - name: Execute smoke tests
-      run: docker run --rm -i -t -v $PWD:/workdir jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
+      run: docker run --rm -v $PWD:/workdir jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
 
     

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -28,15 +28,13 @@ jobs:
         java-version: 17
     - name: Build with Maven
       run: mvn -B package --file pom.xml -Dmaven.test.skip=true
-    - name: Download and install HTTP client
-      run: |
-        curl -f -L -o ijhttp.zip "https://jb.gg/ijhttp/latest"
-        unzip ijhttp.zip
+    - name: Docker Pull HTTP client
+      run: docker pull jetbrains/intellij-http-client
     - name: Start server with jetty
       run: |
         mvn jetty:run & export JPA_PROCESS=$!
         sleep 60
     - name: Execute smoke tests
-      run: ./ijhttp/ijhttp ./src/test/smoketest/plain_server.http --env-file ./src/test/smoketest/http-client.env.json --env default
+      run: docker run --rm -i -t -v $PWD:/workdir jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
 
     

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Start server with jetty
       run: |
         mvn jetty:run & export JPA_PROCESS=$!
-        sleep 10
+        sleep 80
     - name: Execute smoke tests
       run: docker run --rm -v $PWD:/workdir --add-host host.docker.internal:host-gateway jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -35,6 +35,6 @@ jobs:
         mvn jetty:run & export JPA_PROCESS=$!
         sleep 80
     - name: Execute smoke tests
-      run: docker run --rm -v $PWD:/workdir jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
+      run: docker run --rm -v $PWD:/workdir --add-host host.docker.internal:host-gateway jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
 
     

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Start server with jetty
       run: |
         mvn jetty:run & export JPA_PROCESS=$!
-        sleep 80
+        sleep 10
     - name: Execute smoke tests
       run: docker run --rm -v $PWD:/workdir --add-host host.docker.internal:host-gateway jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
 


### PR DESCRIPTION
For smoke test pipeline:

Uses a docker pull to get the IntelliJ HTTP client instead of a direct url.