### PR TITLE
Merge smoke testing docker updates to release tracking branch

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -28,15 +28,13 @@ jobs:
         java-version: 17
     - name: Build with Maven
       run: mvn -B package --file pom.xml -Dmaven.test.skip=true
-    - name: Download and install HTTP client
-      run: |
-        curl -f -L -o ijhttp.zip "https://jb.gg/ijhttp/latest"
-        unzip ijhttp.zip
+    - name: Docker Pull HTTP client
+      run: docker pull jetbrains/intellij-http-client
     - name: Start server with jetty
       run: |
         mvn jetty:run & export JPA_PROCESS=$!
-        sleep 60
+        sleep 80
     - name: Execute smoke tests
-      run: ./ijhttp/ijhttp ./src/test/smoketest/plain_server.http --env-file ./src/test/smoketest/http-client.env.json --env default
+      run: docker run --rm -v $PWD:/workdir --add-host host.docker.internal:host-gateway jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default
 
     

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-            <version>6.5.21-SNAPSHOT</version>
+            <version>6.6.0</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-            <version>6.5.20-SNAPSHOT</version>
+            <version>6.5.21-SNAPSHOT</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>


### PR DESCRIPTION
Updates the release tracking branch with the latest switch to using docker to run the http client for smoke tests. 