### PR TITLE
remove redundant/unused reload-existing-ig property

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -74,7 +74,6 @@ public class AppProperties {
   private Cors cors = null;
   private Partitioning partitioning = null;
   private Boolean install_transitive_ig_dependencies = true;
-  private Boolean reload_existing_implementationguides = false;
   private Map<String, PackageInstallationSpec> implementationGuides = null;
 
 	private String staticLocation = null;
@@ -565,14 +564,6 @@ public class AppProperties {
 		this.install_transitive_ig_dependencies = install_transitive_ig_dependencies;
 	}
 	
-	public boolean getReload_existing_implementationguides() {
-		return reload_existing_implementationguides;
-	}
-	
-	public void setReload_existing_implementationguides(boolean reload_existing_implementationguides) {
-		this.reload_existing_implementationguides = reload_existing_implementationguides;
-	}
-
 	public Integer getBundle_batch_pool_size() {
 		return this.bundle_batch_pool_size;
 	}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -75,8 +75,6 @@ hapi:
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
     #    install_transitive_ig_dependencies: true
-    ### tells the server whether to attempt to load IG resources that are already present
-    #    reload_existing_implementationGuides : false
     #implementationguides:
     ###    example from registry (packages.fhir.org)
     #  swiss:


### PR DESCRIPTION
This PR made the "reload_existing_implementationGuides" property no longer needed or picked up: 
https://github.com/hapifhir/hapi-fhir-jpaserver-starter/pull/577

The property is now part of the PackageInstallerSpec. Removing it for cleanup and to avoid confusion. 