### PR TITLE
Affected Issue(s): #606

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -27,6 +27,7 @@ public class AppProperties {
   private Boolean ips_enabled = false;
   private Boolean openapi_enabled = false;
   private Boolean mdm_enabled = false;
+  private String mdm_rules_json_location = "mdm-rules.json";
   private boolean advanced_lucene_indexing = false;
   private boolean enable_index_of_type = false;
   private Boolean allow_cascading_deletes = false;
@@ -189,7 +190,15 @@ public class AppProperties {
     this.mdm_enabled = mdm_enabled;
   }
 
-  public Cors getCors() {
+  public String getMdm_rules_json_location() {
+	return mdm_rules_json_location;
+}
+
+public void setMdm_rules_json_location(String mdm_rules_json_location) {
+	this.mdm_rules_json_location = mdm_rules_json_location;
+}
+
+public Cors getCors() {
     return cors;
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mdm/MdmConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mdm/MdmConfig.java
@@ -26,7 +26,7 @@ public class MdmConfig {
 	@Bean
 	IMdmSettings mdmSettings(@Autowired MdmRuleValidator theMdmRuleValidator, AppProperties appProperties) throws IOException {
 		DefaultResourceLoader resourceLoader = new DefaultResourceLoader();
-		Resource resource = resourceLoader.getResource("mdm-rules.json");
+		Resource resource = resourceLoader.getResource(appProperties.getMdm_rules_json_location());
 		String json = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
 		return new MdmSettings(theMdmRuleValidator).setEnabled(appProperties.getMdm_enabled()).setScriptText(json);
 	}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -132,6 +132,7 @@ hapi:
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
     mdm_enabled: false
+    mdm_rules_json_location: "mdm-rules.json"
     #    partitioning:
     #      allow_references_across_partitions: false
     #      partitioning_include_in_search_hashes: false


### PR DESCRIPTION
This correlates to #606

What this commit has achieved:
1. Externalized location of "mdm-rules.json" in the `AppProperties`
2. More info about the `ResourceLoader` interface is available at [here](https://docs.spring.io/spring-framework/reference/core/resources.html#resources-resourceloader)

### Example usage
- Set `hapi.fhir.mdm_rules_json_location` to `file:///D:/SourceCodes/SID/it-team/local-development-resources/federated-fhir-servers-prototype/district-a/mdm-rules.json`