### PR TITLE
Affected Issue(s): #611

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -180,6 +180,13 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_size());
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_max_size());
 
+		if (appProperties.getMdm_enabled()) {
+			// MDM requires the subscription of type message
+			ourLog.info("Enabling message subscriptions");
+			jpaStorageSettings.addSupportedSubscriptionType(
+					org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.MESSAGE);
+		}
+
 		storageSettings(appProperties, jpaStorageSettings);
 		return jpaStorageSettings;
 	}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mdm/MdmConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mdm/MdmConfig.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.starter.mdm;
 
 import ca.uhn.fhir.jpa.mdm.config.MdmConsumerConfig;
 import ca.uhn.fhir.jpa.mdm.config.MdmSubmitterConfig;
+import ca.uhn.fhir.jpa.searchparam.config.NicknameServiceConfig;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.mdm.api.IMdmSettings;
 import ca.uhn.fhir.mdm.rules.config.MdmRuleValidator;
@@ -20,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 
 @Configuration
 @Conditional(MdmConfigCondition.class)
-@Import({MdmConsumerConfig.class, MdmSubmitterConfig.class})
+@Import({MdmConsumerConfig.class, MdmSubmitterConfig.class, NicknameServiceConfig.class})
 public class MdmConfig {
 
 	@Bean

--- a/src/test/java/ca/uhn/fhir/jpa/starter/MdmTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/MdmTest.java
@@ -1,0 +1,29 @@
+package ca.uhn.fhir.jpa.starter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.nickname.INicknameSvc;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class}, properties = {
+		"hapi.fhir.fhir_version=r4",
+		"hapi.fhir.mdm_enabled=true"
+})
+class MdmTest {
+	@Autowired
+	INicknameSvc nicknameService;
+	
+	@Autowired
+	JpaStorageSettings jpaStorageSettings;
+
+	@Test
+	void testApplicationStartedSuccessfully() {
+		assertThat(nicknameService).isNotNull();
+		assertThat(jpaStorageSettings.getSupportedSubscriptionTypes()).contains(SubscriptionChannelType.MESSAGE);
+	}
+}


### PR DESCRIPTION
This will close #611 if merged.

What this commit has achieved:
1. MDM requires an implementation of `INicknameSvc`, it was instantiated in `NicknameServiceConfig`
The error message regarding this was:
```
APPLICATION FAILED TO START

Description:

Parameter 2 of method matcherFactory in ca.uhn.fhir.jpa.mdm.config.MdmCommonConfig required a bean of type 'ca.uhn.fhir.jpa.nickname.INicknameSvc' that could not be found.

Action:

Consider defining a bean of type 'ca.uhn.fhir.jpa.nickname.INicknameSvc' in your configuration.
```

2. MDM requires the subscription of type message
The error message regarding this was:
```
2023-12-01 11:34:03 org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'mdmSubmitterInterceptorLoader': Invocation of init method failed; nested exception is ca.uhn.fhir.context.ConfigurationException: HAPI-2421: MDM requires Message Subscriptions to be enabled in the Storage Settings
```