### PR TITLE
Bump github actions used in docker build workflow

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Container meta for default (distroless) image
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGES }}
           tags: |
@@ -30,7 +30,7 @@ jobs:
 
       - name: Container meta for tomcat image
         id: docker_tomcat_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.IMAGES }}
           tags: |
@@ -39,20 +39,20 @@ jobs:
             suffix=-tomcat,onlatest=true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build and push default (distroless) image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build and push tomcat image
         id: docker_build_tomcat
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
This bumps all GitHub actions to most recent versions in the docker image build workflow.