### PR TITLE
Explicit profile for smoke test invocation

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,7 +33,7 @@ jobs:
       run: docker pull jetbrains/intellij-http-client
     - name: Start server with jetty
       run: |
-        mvn jetty:run & export JPA_PROCESS=$!
+        mvn -Pjetty jetty:run & export JPA_PROCESS=$!
         sleep 80
     - name: Execute smoke tests
       run: docker run --rm -v $PWD:/workdir --add-host host.docker.internal:host-gateway jetbrains/intellij-http-client -D src/test/smoketest/plain_server.http --env-file src/test/smoketest/http-client.env.json --env default


### PR DESCRIPTION
The smoke tests appear to be failing due to an inability to start the server.

This explicitly sets the profile before running.