### PR TITLE
feat: Add sample elasticsearch index prefix config.

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -85,6 +85,7 @@ public class AppProperties {
 
   private Boolean lastn_enabled = false;
   private boolean store_resource_in_lucene_index_enabled = false;
+  private String elasticsearch_index_prefix = "";
   private NormalizedQuantitySearchLevel normalized_quantity_search_level = NormalizedQuantitySearchLevel.NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED;
 
   private Boolean use_apache_address_strategy = false;
@@ -558,6 +559,14 @@ public Cors getCors() {
 
 	public void setStore_resource_in_lucene_index_enabled(Boolean store_resource_in_lucene_index_enabled) {
 		this.store_resource_in_lucene_index_enabled = store_resource_in_lucene_index_enabled;
+	}
+
+	public String getElasticsearch_index_prefix() {
+		return elasticsearch_index_prefix;
+	}
+
+	public void setElasticsearch_index_prefix(String elasticsearch_index_prefix) {
+		this.elasticsearch_index_prefix = elasticsearch_index_prefix;
 	}
 
 	public NormalizedQuantitySearchLevel getNormalized_quantity_search_level() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -160,6 +160,10 @@ public class FhirServerConfigCommon {
 			jpaStorageSettings.setInlineResourceTextBelowSize(appProperties.getInline_resource_storage_below_size());
 		}
 
+		if (appProperties.getElasticsearch_index_prefix() != null && !appProperties.getElasticsearch_index_prefix().isEmpty()) {
+			jpaStorageSettings.setHSearchIndexPrefix(appProperties.getElasticsearch_index_prefix());
+		}
+
 		jpaStorageSettings.setStoreResourceInHSearchIndex(appProperties.getStore_resource_in_lucene_index_enabled());
 		jpaStorageSettings.setNormalizedQuantitySearchLevel(appProperties.getNormalized_quantity_search_level());
 		jpaStorageSettings.setIndexOnContainedResources(appProperties.getEnable_index_contained_resource());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -220,6 +220,7 @@ hapi:
 #        quitWait:
 #    lastn_enabled: true
 #    store_resource_in_lucene_index_enabled: true
+#    elasticsearch_index_prefix: "prefix"
 ###  This is configuration for normalized quantity search level default is 0
 ###   0: NORMALIZED_QUANTITY_SEARCH_NOT_SUPPORTED - default
 ###   1: NORMALIZED_QUANTITY_STORAGE_SUPPORTED


### PR DESCRIPTION
# Summary

* Allow the definition of an Elasticsearch prefix using hapi.fhir.elasticsearch_index_prefix. This adds a prefix only for termconcept-* and resourcetable-*. It will not affect the index of the lastN operation.

## Usage Example

Configuring hapi.fhir.elasticsearch_index_prefix: "myPrefix" results in indices named myPrefix-termconcept-* and myPrefix-resourcetable-*.

# Link issues
* https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/429