### PR TITLE
Allow all client_id_strategy options and add server_id_strategy

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.jpa.starter;
 
 import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings.ClientIdStrategyEnum;
+import ca.uhn.fhir.jpa.api.config.JpaStorageSettings.IdStrategyEnum;
 import ca.uhn.fhir.jpa.model.entity.NormalizedQuantitySearchLevel;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
 import ca.uhn.fhir.rest.api.EncodingEnum;
@@ -65,6 +66,7 @@ public class AppProperties {
   private EncodingEnum default_encoding = EncodingEnum.JSON;
   private FhirVersionEnum fhir_version = FhirVersionEnum.R4;
   private ClientIdStrategyEnum client_id_strategy = ClientIdStrategyEnum.ALPHANUMERIC;
+  private IdStrategyEnum server_id_strategy = null;
   private List<String> supported_resource_types = new ArrayList<>();
   private List<Bundle.BundleType> allowed_bundle_types = null;
   private Boolean narrative_enabled = true;
@@ -259,7 +261,15 @@ public Cors getCors() {
     this.client_id_strategy = client_id_strategy;
   }
 
-	public boolean getAdvanced_lucene_indexing() {
+  public IdStrategyEnum getServer_id_strategy() {
+    return server_id_strategy;
+  }
+
+  public void setServer_id_strategy(IdStrategyEnum server_id_strategy) {
+    this.server_id_strategy = server_id_strategy;
+  }
+
+  public boolean getAdvanced_lucene_indexing() {
 		return this.advanced_lucene_indexing;
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -174,10 +174,27 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setDeferIndexingForCodesystemsOfSize(
 				appProperties.getDefer_indexing_for_codesystems_of_size());
 
+		jpaStorageSettings.setResourceClientIdStrategy(appProperties.getClient_id_strategy());
+		ourLog.info("Server configured to use '" + appProperties.getClient_id_strategy() + "' Client ID Strategy");
+
+		// Set and/or recommend default Server ID Strategy of UUID when using the ANY Client ID Strategy
 		if (appProperties.getClient_id_strategy() == JpaStorageSettings.ClientIdStrategyEnum.ANY) {
-			jpaStorageSettings.setResourceServerIdStrategy(JpaStorageSettings.IdStrategyEnum.UUID);
-			jpaStorageSettings.setResourceClientIdStrategy(appProperties.getClient_id_strategy());
+			if (appProperties.getServer_id_strategy() == null) {
+				ourLog.info("Defaulting server to use '" + JpaStorageSettings.IdStrategyEnum.UUID
+						+ "' Server ID Strategy when using the '" + JpaStorageSettings.ClientIdStrategyEnum.ANY
+						+ "' Client ID Strategy");
+				appProperties.setServer_id_strategy(JpaStorageSettings.IdStrategyEnum.UUID);
+			} else if (appProperties.getServer_id_strategy() != JpaStorageSettings.IdStrategyEnum.UUID) {
+				ourLog.warn("WARNING: '" + JpaStorageSettings.IdStrategyEnum.UUID
+						+ "' Server ID Strategy is highly recommended when using the '"
+						+ JpaStorageSettings.ClientIdStrategyEnum.ANY + "' Client ID Strategy");
+			}
 		}
+		if (appProperties.getServer_id_strategy() != null) {
+			jpaStorageSettings.setResourceServerIdStrategy(appProperties.getServer_id_strategy());
+			ourLog.info("Server configured to use '" + appProperties.getServer_id_strategy() + "' Server ID Strategy");
+		}
+
 		// Parallel Batch GET execution settings
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_size());
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_max_size());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -139,6 +139,7 @@ hapi:
     #    etag_support_enabled: true
     #    expunge_enabled: true
     #    client_id_strategy: ALPHANUMERIC
+    #    server_id_strategy: SEQUENTIAL_NUMERIC
     #    fhirpath_interceptor_enabled: false
     #    filter_search_enabled: true
     #    graphql_enabled: true


### PR DESCRIPTION
Per #649 this PR aims to add a new config property to the JPA Server Starter for `server_id_strategy` with some defaulting logic based on what is set for `client_id_strategy`, while at the same time opens up `client_id_strategy` to all possible values (and not just default a.k.a. `ALPHANUMERIC` vs `ANY` which were really the only two options before).

For example, now you can set `client_id_strategy` to `NOT_ALLOWED` which was not possible before (or more to say, sure, you could have set the property to this value, but it would not have actually set the JpaStorageSetting property to anything).

The new `server_id_strategy` is set to null by default and then will be changed to `UUID` if `client_id_strategy` was set to `ANY` (exactly as it was before) provided that `server_id_strategy` has not been explicitly set to anything else.

If `client_id_strategy` is set to `ANY` and `server_id_strategy` is explicitly set to anything other than `UUID`, a warning will be printed in the log during startup of the server.

Here is how it now looks in the log for different cases:

```sh
# default:
2024-02-28 14:16:20.874 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:178] Server configured to use 'ALPHANUMERIC' Client ID Strategy

# with `HAPI_FHIR_CLIENT_ID_STRATEGY=ANY ...`
2024-02-28 14:17:20.128 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:178] Server configured to use 'ANY' Client ID Strategy
2024-02-28 14:17:20.129 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:183] Defaulting server to use 'UUID' Server ID Strategy when using the 'ANY' Client ID Strategy
2024-02-28 14:17:20.129 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:195] Server configured to use 'UUID' Server ID Strategy

# with `HAPI_FHIR_CLIENT_ID_STRATEGY=NOT_ALLOWED ...`
2024-02-28 14:18:51.495 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:178] Server configured to use 'NOT_ALLOWED' Client ID Strategy

# with `HAPI_FHIR_SERVER_ID_STRATEGY=UUID ...`
2024-02-28 14:19:57.649 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:178] Server configured to use 'ALPHANUMERIC' Client ID Strategy
2024-02-28 14:19:57.649 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:195] Server configured to use 'UUID' Server ID Strategy

# with `HAPI_FHIR_CLIENT_ID_STRATEGY=ANY HAPI_FHIR_SERVER_ID_STRATEGY=SEQUENTIAL_NUMERIC ...`
2024-02-28 14:21:10.440 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:178] Server configured to use 'ANY' Client ID Strategy
2024-02-28 14:21:10.440 [main] WARN  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:188] WARNING: 'UUID' Server ID Strategy is highly recommended when using the 'ANY' Client ID Strategy
2024-02-28 14:21:10.441 [main] INFO  c.u.f.j.s.c.FhirServerConfigCommon [FhirServerConfigCommon.java:195] Server configured to use 'SEQUENTIAL_NUMERIC' Server ID Strategy
```

Formatting and content of the log messages is certainly up for debate, but hopefully this is a good start!
