### PR TITLE
fhir version of Parameters for IG uninstall when using R5

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/ig/ImplementationGuideR5OperationProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/ig/ImplementationGuideR5OperationProvider.java
@@ -35,9 +35,9 @@ public class ImplementationGuideR5OperationProvider implements IImplementationGu
 
 
 	@Operation(name = "$uninstall", typeName = "ImplementationGuide")
-	public org.hl7.fhir.r4.model.Parameters uninstall(@OperationParam(name = "name", min = 1, max = 1) String name, @OperationParam(name = "version", min = 1, max = 1) String version) {
+	public Parameters uninstall(@OperationParam(name = "name", min = 1, max = 1) String name, @OperationParam(name = "version", min = 1, max = 1) String version) {
 
 		packageInstallerSvc.uninstall(new PackageInstallationSpec().setName(name).setVersion(version));
-		return new org.hl7.fhir.r4.model.Parameters();
+		return new Parameters();
 	}
 }


### PR DESCRIPTION
When using R5 and enabling ig_runtime_upload_enabled, the application won't start.

We need to change the package of the Parameters resource used in ImplementationGuideR5OperationProvider.uninstall (probably a copy&paste with too much information carried over).