### PR TITLE
Updating to 7.3.0-SNAPSHOT to enable new CR operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>7.0.2</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -2,7 +2,7 @@ package ca.uhn.fhir.jpa.starter.common;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.binary.api.IBinaryStorageSvc;
-import ca.uhn.fhir.jpa.binstore.DatabaseBlobBinaryStorageSvcImpl;
+import ca.uhn.fhir.jpa.binstore.DatabaseBinaryContentStorageSvcImpl;
 import ca.uhn.fhir.jpa.config.HibernatePropertiesProvider;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings.CrossPartitionReferenceMode;
@@ -261,7 +261,7 @@ public class FhirServerConfigCommon {
 	@Lazy
 	@Bean
 	public IBinaryStorageSvc binaryStorageSvc(AppProperties appProperties) {
-		DatabaseBlobBinaryStorageSvcImpl binaryStorageSvc = new DatabaseBlobBinaryStorageSvcImpl();
+		DatabaseBinaryContentStorageSvcImpl binaryStorageSvc = new DatabaseBinaryContentStorageSvcImpl();
 
 		if (appProperties.getMax_binary_size() != null) {
 			binaryStorageSvc.setMaximumBinarySize(appProperties.getMax_binary_size());

--- a/src/main/java/ca/uhn/fhir/jpa/starter/cr/StarterCrR4Config.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/cr/StarterCrR4Config.java
@@ -68,7 +68,6 @@ public class StarterCrR4Config {
 	@Bean
 	CareGapsProperties careGapsProperties(CrProperties theCrProperties) {
 		var careGapsProperties = new CareGapsProperties();
-		careGapsProperties.setThreadedCareGapsEnabled(false);
 		careGapsProperties.setCareGapsReporter(theCrProperties.getCareGapsReporter());
 		careGapsProperties.setCareGapsCompositionSectionAuthor(theCrProperties.getCareGapsSectionAuthor());
 		return careGapsProperties;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/ips/StarterIpsConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/ips/StarterIpsConfig.java
@@ -6,7 +6,7 @@ import ca.uhn.fhir.jpa.ips.api.IIpsGenerationStrategy;
 import ca.uhn.fhir.jpa.ips.generator.IIpsGeneratorSvc;
 import ca.uhn.fhir.jpa.ips.generator.IpsGeneratorSvcImpl;
 import ca.uhn.fhir.jpa.ips.provider.IpsOperationProvider;
-import ca.uhn.fhir.jpa.ips.strategy.DefaultIpsGenerationStrategy;
+import ca.uhn.fhir.jpa.ips.jpa.DefaultJpaIpsGenerationStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Conditional;
 public class StarterIpsConfig {
 	@Bean
 	IIpsGenerationStrategy ipsGenerationStrategy() {
-		return new DefaultIpsGenerationStrategy();
+		return new DefaultJpaIpsGenerationStrategy();
 	}
 
 	@Bean
@@ -25,6 +25,6 @@ public class StarterIpsConfig {
 	@Bean
 	public IIpsGeneratorSvc ipsGeneratorSvcImpl(
 			FhirContext theFhirContext, IIpsGenerationStrategy theGenerationStrategy, DaoRegistry theDaoRegistry) {
-		return new IpsGeneratorSvcImpl(theFhirContext, theGenerationStrategy, theDaoRegistry);
+		return new IpsGeneratorSvcImpl(theFhirContext, theGenerationStrategy);
 	}
 }


### PR DESCRIPTION
I'm helping to develop the eCQM Testing Tool (https://github.com/cqframework/ecqm-measure-test) and we wanted to update our hapi fhir endpoint to enable some CR operations and test with them (namely $data-requirements and $collect-data.) This PR simply makes the few changes to class names I found were needed to get the endpoint to run properly using the 7.3.0-SNAPSHOT version of hapi-fhir. Currently the master branch uses 7.0.2 of hapi-fhir which does not have these operations enabled yet.

If anything in this PR seems out of place, or missing, by all means please weigh in. We would very much like to ensure we have properly configured things for our tool.