### PR TITLE
Docker + Tomcat: lucene directory creation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ RUN mkdir /app && cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.
 ########### it can be built using eg. `docker build --target tomcat .`
 FROM bitnami/tomcat:10.1 AS tomcat
 
+USER root
 RUN rm -rf /opt/bitnami/tomcat/webapps/ROOT && \
     mkdir -p /opt/bitnami/hapi/data/hapi/lucenefiles && \
+    chown -R 1001:1001 /opt/bitnami/hapi/data/hapi/lucenefiles && \
     chmod 775 /opt/bitnami/hapi/data/hapi/lucenefiles
 
-USER root
 RUN mkdir -p /target && chown -R 1001:1001 target
 USER 1001
 


### PR DESCRIPTION
The directory created for lucene requires escalated privileges to be created. 

This uses ROOT for directory creation, but switches ownership back to 1001 after creation.

Fixes #719 