### PR TITLE
Updated FHIR to 7.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/library/maven:3.9.7-eclipse-temurin-17 AS build-hapi
+FROM docker.io/library/maven:3.9.9-eclipse-temurin-17 AS build-hapi
 WORKDIR /tmp/hapi-fhir-jpaserver-starter
 
-ARG OPENTELEMETRY_JAVA_AGENT_VERSION=1.33.3
+ARG OPENTELEMETRY_JAVA_AGENT_VERSION=1.33.5
 RUN curl -LSsO https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OPENTELEMETRY_JAVA_AGENT_VERSION}/opentelemetry-javaagent.jar
 
 COPY pom.xml .

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>7.2.1</version>
+        <version>7.4.0</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
@@ -354,14 +354,14 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.11.3</version>
+            <version>1.13.3</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.11.3</version>
+            <version>1.13.3</version>
         </dependency>
 
         <dependency>
@@ -402,7 +402,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.4.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.jpa.binstore.DatabaseBinaryContentStorageSvcImpl;
 import ca.uhn.fhir.jpa.config.HibernatePropertiesProvider;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings.CrossPartitionReferenceMode;
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import ca.uhn.fhir.jpa.model.entity.StorageSettings;
 import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.util.JpaHibernatePropertiesProvider;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
 /**
  * This is the primary configuration file for the example server
  */
+@SuppressWarnings("ALL")
 @Configuration
 @EnableTransactionManagement
 public class FhirServerConfigCommon {
@@ -114,10 +116,6 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setDeleteExpungeEnabled(appProperties.getDelete_expunge_enabled());
 		jpaStorageSettings.setExpungeEnabled(appProperties.getExpunge_enabled());
 		jpaStorageSettings.setLanguageSearchParameterEnabled(appProperties.getLanguage_search_parameter_enabled());
-		if (appProperties.getSubscription() != null
-				&& appProperties.getSubscription().getEmail() != null)
-			jpaStorageSettings.setEmailFromAddress(
-					appProperties.getSubscription().getEmail().getFrom());
 
 		Integer maxFetchSize = appProperties.getMax_page_size();
 		jpaStorageSettings.setFetchSizeDefaultMaximum(maxFetchSize);
@@ -130,25 +128,6 @@ public class FhirServerConfigCommon {
 
 		Long retainCachedSearchesMinutes = appProperties.getRetain_cached_searches_mins();
 		jpaStorageSettings.setExpireSearchResultsAfterMillis(retainCachedSearchesMinutes * 60 * 1000);
-
-		if (appProperties.getSubscription() != null) {
-			// Subscriptions are enabled by channel type
-			if (appProperties.getSubscription().getResthook_enabled()) {
-				ourLog.info("Enabling REST-hook subscriptions");
-				jpaStorageSettings.addSupportedSubscriptionType(
-						org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.RESTHOOK);
-			}
-			if (appProperties.getSubscription().getEmail() != null) {
-				ourLog.info("Enabling email subscriptions");
-				jpaStorageSettings.addSupportedSubscriptionType(
-						org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.EMAIL);
-			}
-			if (appProperties.getSubscription().getWebsocket_enabled()) {
-				ourLog.info("Enabling websocket subscriptions");
-				jpaStorageSettings.addSupportedSubscriptionType(
-						org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.WEBSOCKET);
-			}
-		}
 
 		jpaStorageSettings.setFilterParameterEnabled(appProperties.getFilter_search_enabled());
 		jpaStorageSettings.setAdvancedHSearchIndexing(appProperties.getAdvanced_lucene_indexing());
@@ -204,15 +183,46 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_size());
 		jpaStorageSettings.setBundleBatchPoolSize(appProperties.getBundle_batch_pool_max_size());
 
+		storageSettings(appProperties, jpaStorageSettings);
+		return jpaStorageSettings;
+	}
+
+	@Bean
+	public SubscriptionSettings subscriptionSettings(AppProperties appProperties) {
+		SubscriptionSettings subscriptionSettings = new SubscriptionSettings();
+
+		if (appProperties.getSubscription() != null) {
+			if(appProperties.getSubscription().getEmail() != null) {
+				subscriptionSettings.setEmailFromAddress(
+					appProperties.getSubscription().getEmail().getFrom());
+			}
+
+			// Subscriptions are enabled by channel type
+			if (appProperties.getSubscription().getResthook_enabled()) {
+				ourLog.info("Enabling REST-hook subscriptions");
+				subscriptionSettings.addSupportedSubscriptionType(
+					org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.RESTHOOK);
+			}
+			if (appProperties.getSubscription().getEmail() != null) {
+				ourLog.info("Enabling email subscriptions");
+				subscriptionSettings.addSupportedSubscriptionType(
+					org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.EMAIL);
+			}
+			if (appProperties.getSubscription().getWebsocket_enabled()) {
+				ourLog.info("Enabling websocket subscriptions");
+				subscriptionSettings.addSupportedSubscriptionType(
+					org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.WEBSOCKET);
+			}
+		}
+
 		if (appProperties.getMdm_enabled()) {
 			// MDM requires the subscription of type message
 			ourLog.info("Enabling message subscriptions");
-			jpaStorageSettings.addSupportedSubscriptionType(
-					org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.MESSAGE);
+			subscriptionSettings.addSupportedSubscriptionType(
+				org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.MESSAGE);
 		}
 
-		storageSettings(appProperties, jpaStorageSettings);
-		return jpaStorageSettings;
+		return subscriptionSettings;
 	}
 
 	@Bean
@@ -251,10 +261,6 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setAllowExternalReferences(appProperties.getAllow_external_references());
 		jpaStorageSettings.setDefaultSearchParamsCanBeOverridden(
 				appProperties.getAllow_override_default_search_params());
-		if (appProperties.getSubscription() != null
-				&& appProperties.getSubscription().getEmail() != null)
-			jpaStorageSettings.setEmailFromAddress(
-					appProperties.getSubscription().getEmail().getFrom());
 
 		jpaStorageSettings.setNormalizedQuantitySearchLevel(appProperties.getNormalized_quantity_search_level());
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -30,6 +30,7 @@ import ca.uhn.fhir.jpa.graphql.GraphQLProvider;
 import ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor;
 import ca.uhn.fhir.jpa.interceptor.validation.RepositoryValidatingInterceptor;
 import ca.uhn.fhir.jpa.ips.provider.IpsOperationProvider;
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import ca.uhn.fhir.jpa.packages.IPackageInstallerSvc;
 import ca.uhn.fhir.jpa.packages.PackageInstallationSpec;
 import ca.uhn.fhir.jpa.partition.PartitionManagementProvider;
@@ -252,6 +253,7 @@ public class StarterJpaConfig {
 			IJpaSystemProvider jpaSystemProvider,
 			ResourceProviderFactory resourceProviderFactory,
 			JpaStorageSettings jpaStorageSettings,
+			SubscriptionSettings subscriptionSettings,
 			ISearchParamRegistry searchParamRegistry,
 			IValidationSupport theValidationSupport,
 			DatabaseBackedPagingProvider databaseBackedPagingProvider,
@@ -378,7 +380,7 @@ public class StarterJpaConfig {
 
 		corsInterceptor.ifPresent(fhirServer::registerInterceptor);
 
-		if (jpaStorageSettings.getSupportedSubscriptionTypes().size() > 0) {
+		if (!subscriptionSettings.getSupportedSubscriptionTypes().isEmpty()) {
 			// Subscription debug logging
 			fhirServer.registerInterceptor(new SubscriptionDebugLogInterceptor());
 		}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/MdmTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/MdmTest.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.starter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,11 +20,11 @@ class MdmTest {
 	INicknameSvc nicknameService;
 	
 	@Autowired
-	JpaStorageSettings jpaStorageSettings;
+	SubscriptionSettings subscriptionSettings;
 
 	@Test
 	void testApplicationStartedSuccessfully() {
 		assertThat(nicknameService).isNotNull();
-		assertThat(jpaStorageSettings.getSupportedSubscriptionTypes()).contains(SubscriptionChannelType.MESSAGE);
+		assertThat(subscriptionSettings.getSupportedSubscriptionTypes()).contains(SubscriptionChannelType.MESSAGE);
 	}
 }

--- a/src/test/java/ca/uhn/fhir/jpa/starter/SubscriptionSettingsConfig.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/SubscriptionSettingsConfig.java
@@ -1,6 +1,7 @@
 package ca.uhn.fhir.jpa.starter;
 
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
 import org.hl7.fhir.dstu2.model.Subscription;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,11 +10,11 @@ import org.springframework.context.annotation.Profile;
 
 @Profile("storageSettingsTest")
 @Configuration
-public class JpaStorageSettingsConfig {
+public class SubscriptionSettingsConfig {
 	@Primary
 	@Bean
-	public JpaStorageSettings storageSettings() {
-		JpaStorageSettings retVal = new JpaStorageSettings();
+	public SubscriptionSettings subscriptionSettings() {
+		SubscriptionSettings retVal = new SubscriptionSettings();
 
 		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
 		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.MESSAGE);


### PR DESCRIPTION
- Updated HAPI FHIR to 7.4.0
- Configuration of Subscription Settings due to Jpa API Changes
- Upgrade of Docker Base image for Maven to 3.9.9
- Upgrade OpenTelemetry dependency


The JpaSettings have been changed in the HAPI FHIR library and now the Subscriptions are not anymore configurable through JpaSettings. This leads also to a tests that fails, but i couldn't find any documentation related to it. All i could find is the documentation about the Subscription Debug Log Interceptor.