### PR TITLE
Config property for validate resource status

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -80,6 +80,7 @@ public class AppProperties {
   private Subscription subscription = new Subscription();
   private Cors cors = null;
   private Partitioning partitioning = null;
+  private Boolean validate_resource_status_for_package_upload = true;
   private Boolean install_transitive_ig_dependencies = true;
   private Map<String, PackageInstallationSpec> implementationGuides = null;
 
@@ -584,6 +585,14 @@ public Cors getCors() {
 	
 	public void setInstall_transitive_ig_dependencies(boolean install_transitive_ig_dependencies) {
 		this.install_transitive_ig_dependencies = install_transitive_ig_dependencies;
+	}
+
+  public Boolean getValidate_resource_status_for_package_upload() {
+		return validate_resource_status_for_package_upload;
+	}
+
+	public void setValidate_resource_status_for_package_upload(Boolean validate_resource_status_for_package_upload) {
+		this.validate_resource_status_for_package_upload = validate_resource_status_for_package_upload;
 	}
 
 	public Integer getBundle_batch_pool_size() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -149,7 +149,7 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setDeleteExpungeEnabled(appProperties.getDelete_expunge_enabled());
 		jpaStorageSettings.setExpungeEnabled(appProperties.getExpunge_enabled());
 		jpaStorageSettings.setLanguageSearchParameterEnabled(appProperties.getLanguage_search_parameter_enabled());
-
+		jpaStorageSettings.setValidateResourceStatusForPackageUpload(appProperties.getValidate_resource_status_for_package_upload());
 
 		Integer maxFetchSize = appProperties.getMax_page_size();
 		jpaStorageSettings.setFetchSizeDefaultMaximum(maxFetchSize);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -149,12 +149,8 @@ public class FhirServerConfigCommon {
 		jpaStorageSettings.setDeleteExpungeEnabled(appProperties.getDelete_expunge_enabled());
 		jpaStorageSettings.setExpungeEnabled(appProperties.getExpunge_enabled());
 		jpaStorageSettings.setLanguageSearchParameterEnabled(appProperties.getLanguage_search_parameter_enabled());
-<<<<<<< HEAD
 		jpaStorageSettings.setValidateResourceStatusForPackageUpload(appProperties.getValidate_resource_status_for_package_upload());
-=======
 		jpaStorageSettings.setIndexOnUpliftedRefchains(appProperties.getUpliftedRefchains_enabled());
-
->>>>>>> origin/master
 
 		if (!appProperties.getSearch_prefetch_thresholds().isEmpty()) {
 			jpaStorageSettings.setSearchPreFetchThresholds(appProperties.getSearch_prefetch_thresholds());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -146,6 +146,8 @@ hapi:
     ### enable to set the Server URL
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
+    ### Flag is true by default. This flag filters resources during package installation, allowing only those resources with a valid status (e.g. active) to be installed.
+    #    validate_resource_status_for_package_upload: false 
     #    install_transitive_ig_dependencies: true
     #implementationguides:
     ###    example from registry (packages.fhir.org)

--- a/src/main/resources/cds.application.yaml
+++ b/src/main/resources/cds.application.yaml
@@ -131,6 +131,8 @@ hapi:
     ### enable to set the Server URL
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
+    ### Flag is true by default. This flag filters resources during package installation, allowing only those resources with a valid status (e.g. active) to be installed.
+    #    validate_resource_status_for_package_upload: false 
     #    install_transitive_ig_dependencies: true
     #implementationguides:
     ###    example from registry (packages.fhir.org)

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -67,6 +67,8 @@ hapi:
     ### enable to set the Server URL
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
+    ### Flag is true by default. This flag filters resources during package installation, allowing only those resources with a valid status (e.g. active) to be installed.
+    #    validate_resource_status_for_package_upload: false 
     #    install_transitive_ig_dependencies: true
     #    implementationguides:
     ###    example from registry (packages.fhir.org)


### PR DESCRIPTION
This PR adds the validate_resource_status_for_package_upload configuration parameter to enable override of the default behaviour of filtering resources during package installation based on their status.

Without this configuration, it is not possible to upload StructureDefinition resources with a [status](https://www.hl7.org/fhir/structuredefinition-definitions.html#StructureDefinition.status) of 'draft'.

This feature is required so that resources with a 'draft' state can be installed on a FHIR server for implementation testing prior to publication as 'active'.