### PR TITLE
Improve Stale management

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,11 +9,12 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
-          days-before-issue-stale: 180
+          days-before-issue-stale: 90
           days-before-pr-stale: 45
-          days-before-issue-close: 5
+          days-before-issue-close: 10
           days-before-pr-close: 10
+          exempt-issue-labels: "Bug"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ jobs:
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 10 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
           days-before-issue-stale: 90
           days-before-pr-stale: 45

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 730 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
-          days-before-issue-stale: 730
+          days-before-issue-stale: 180
           days-before-pr-stale: 45
           days-before-issue-close: 5
           days-before-pr-close: 10


### PR DESCRIPTION
In order to make the most of our time managing issues, i am suggesting to reduce drastically the time for tagging as stale and increasing the time for comment / update before closing time.
I would also add a "whitelist" label so it is not affected by it ("bug")