### PR TITLE
add application.yaml setting for conditional_create_duplicate_identifiers_enabled

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -793,6 +793,7 @@ public Cors getCors() {
 
     private Boolean partitioning_include_in_search_hashes = false;
     private Boolean allow_references_across_partitions = false;
+    private Boolean conditional_create_duplicate_identifiers_enabled = false;
 
     public Boolean getPartitioning_include_in_search_hashes() {
       return partitioning_include_in_search_hashes;
@@ -807,6 +808,14 @@ public Cors getCors() {
 
     public void setAllow_references_across_partitions(Boolean allow_references_across_partitions) {
       this.allow_references_across_partitions = allow_references_across_partitions;
+    }
+
+    public Boolean getConditional_create_duplicate_identifiers_enabled() {
+      return conditional_create_duplicate_identifiers_enabled;
+    }
+
+    public void setConditional_create_duplicate_identifiers_enabled(Boolean conditional_create_duplicate_identifiers_enabled) {
+      this.conditional_create_duplicate_identifiers_enabled = conditional_create_duplicate_identifiers_enabled;
     }
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -247,6 +247,8 @@ public class FhirServerConfigCommon {
 			} else {
 				retVal.setAllowReferencesAcrossPartitions(CrossPartitionReferenceMode.NOT_ALLOWED);
 			}
+			retVal.setConditionalCreateDuplicateIdentifiersEnabled(
+				appProperties.getPartitioning().getConditional_create_duplicate_identifiers_enabled());
 		}
 
 		return retVal;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -226,6 +226,7 @@ hapi:
     #    partitioning:
     #      allow_references_across_partitions: false
     #      partitioning_include_in_search_hashes: false
+    #      conditional_create_duplicate_identifiers_enabled: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-

--- a/src/main/resources/cds.application.yaml
+++ b/src/main/resources/cds.application.yaml
@@ -225,6 +225,7 @@ hapi:
     #    partitioning:
     #      allow_references_across_partitions: false
     #      partitioning_include_in_search_hashes: false
+    #      conditional_create_duplicate_identifiers_enabled: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -146,6 +146,7 @@ hapi:
     #    partitioning:
     #      allow_references_across_partitions: false
     #      partitioning_include_in_search_hashes: false
+    #      partitioning_include_in_search_hashes
     #cors:
     #  allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-


### PR DESCRIPTION
Added setting to application.yaml for `conditional_create_duplicate_identifiers_enabled` which was added in hapi-fhir 7.4.0 by https://github.com/hapifhir/hapi-fhir/pull/5983

closes #754