### PR TITLE
Helm chart dependency updates and support for extraVolumes and -Mounts

### DIFF
--- a/.github/ct/config.yaml
+++ b/.github/ct/config.yaml
@@ -12,3 +12,4 @@ upgrade: true
 skip-missing-values: true
 release-label: release
 release-name-template: "helm-v{{ .Version }}"
+target-branch: master

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-22.04
-    container: quay.io/helmpack/chart-testing:v3.10.1@sha256:7d8a7f99fc5840142249cc33ed6d9752fc66b92f9e1bf792d987ee85227d84da
+    container: quay.io/helmpack/chart-testing:v3.11.0@sha256:f2fd21d30b64411105c7eafb1862783236a219d29f2292219a09fe94ca78ad2a
     steps:
       - name: Install helm-docs
         working-directory: /tmp
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        k8s-version: [1.29.8, 1.30.4, 1.31.0]
+        k8s-version: [1.30.8, 1.31.4, 1.32.0]
     needs:
       - lint
     steps:

--- a/charts/hapi-fhir-jpaserver/Chart.lock
+++ b/charts/hapi-fhir-jpaserver/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 15.5.22
-digest: sha256:513750151f1497acfe6ba07fb1833b8d945ca19094f83018d34b339b666a2d56
-generated: "2024-08-18T18:30:23.392457144+02:00"
+  version: 16.3.2
+- name: common
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 2.28.0
+digest: sha256:99587bb3481cd94c1679d9dd23cb8c816701a1c6f0d458c77c71e7e541dd2f55
+generated: "2024-12-17T12:51:15.601470579+01:00"

--- a/charts/hapi-fhir-jpaserver/Chart.yaml
+++ b/charts/hapi-fhir-jpaserver/Chart.yaml
@@ -7,11 +7,14 @@ sources:
   - https://github.com/hapifhir/hapi-fhir-jpaserver-starter
 dependencies:
   - name: postgresql
-    version: 15.5.22
+    version: 16.3.2
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
-appVersion: 7.2.0
-version: 0.17.1
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 2.28.0
+appVersion: 7.6.0
+version: 0.18.0
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/containsSecurityUpdates: "false"
@@ -24,6 +27,14 @@ annotations:
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
     - kind: changed
-      description: updated curlimages/curl to 8.9.1
+      description: "updated postgresql sub-chart to 16.3.2"
     - kind: changed
-      description: "updated postgresql sub-chart to 15.5.22."
+      description: "updated curlimages/curl to 8.11.1"
+    - kind: changed
+      description: "updated hapiproject/hapi to 7.6.0"
+    - kind: added
+      description: "support for setting resource limits and requests from presets. With a default set for all containers"
+    - kind: added
+      description: "support for setting extra volumes and volume mounts"
+    - kind: changed
+      description: "set default pod security context for main and test pods"

--- a/charts/hapi-fhir-jpaserver/README.md
+++ b/charts/hapi-fhir-jpaserver/README.md
@@ -1,6 +1,6 @@
 # HAPI FHIR JPA Server Starter Helm Chart
 
-![Version: 0.17.1](https://img.shields.io/badge/Version-0.17.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.2.0](https://img.shields.io/badge/AppVersion-7.2.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.6.0](https://img.shields.io/badge/AppVersion-7.6.0-informational?style=flat-square)
 
 This helm chart will help you install the HAPI FHIR JPA Server in a Kubernetes environment.
 
@@ -15,7 +15,8 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 15.5.22 |
+| oci://registry-1.docker.io/bitnamicharts | common | 2.28.0 |
+| oci://registry-1.docker.io/bitnamicharts | postgresql | 16.3.2 |
 
 ## Values
 
@@ -32,11 +33,13 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | externalDatabase.user | string | `"fhir"` | username for the external database |
 | extraConfig | string | `""` | additional Spring Boot application config. Mounted as a file and automatically loaded by the application. |
 | extraEnv | list | `[]` | extra environment variables to set on the server container |
+| extraVolumeMounts | list | `[]` | Optionally specify extra list of additional volumeMounts |
+| extraVolumes | list | `[]` | Optionally specify extra list of additional volumes |
 | fullnameOverride | string | `""` | override the chart fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | image pullPolicy to use |
 | image.registry | string | `"docker.io"` | registry where the HAPI FHIR server image is hosted |
 | image.repository | string | `"hapiproject/hapi"` | the path inside the repository |
-| image.tag | string | `"v7.2.0@sha256:9bcafa8342b572eee248cb7c48c496863d352bbd0347e1d98ea238d09620e89b"` | the image tag. As of v5.7.0, this is the `distroless` flavor by default, add `-tomcat` to use the Tomcat-based image. |
+| image.tag | string | `"v7.6.0@sha256:4771a178e764896c83881c1b3a52bd487e53d06e1acc3653ea0db0c6f6b2b8a1"` | the image tag. As of v5.7.0, this is the `distroless` flavor by default, add `-tomcat` to use the Tomcat-based image. |
 | imagePullSecrets | list | `[]` | image pull secrets to use when pulling the image |
 | ingress.annotations | object | `{}` | provide any additional annotations which may be required. Evaluated as a template. |
 | ingress.enabled | bool | `false` | whether to create an Ingress to expose the FHIR server HTTP endpoint |
@@ -44,6 +47,8 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | ingress.hosts[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.hosts[0].paths[0] | string | `"/"` |  |
 | ingress.tls | list | `[]` | ingress TLS config |
+| initContainers.resources | object | `{}` | configure the init containers pods resource requests and limits |
+| initContainers.resourcesPreset | string | `"nano"` | set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (`resources` is recommended for production). More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15> |
 | metrics.service.port | int | `8081` |  |
 | metrics.serviceMonitor.additionalLabels | object | `{}` | additional labels to apply to the ServiceMonitor object, e.g. `release: prometheus` |
 | metrics.serviceMonitor.enabled | bool | `false` | if enabled, creates a ServiceMonitor instance for Prometheus Operator-based monitoring |
@@ -53,12 +58,13 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | podDisruptionBudget.enabled | bool | `false` | Enable PodDisruptionBudget for the server pods. uses policy/v1/PodDisruptionBudget thus requiring k8s 1.21+ |
 | podDisruptionBudget.maxUnavailable | string | `""` | maximum unavailable instances |
 | podDisruptionBudget.minAvailable | int | `1` | minimum available instances |
-| podSecurityContext | object | `{}` | pod security context |
+| podSecurityContext | object | `{"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | pod security context |
 | postgresql.auth.database | string | `"fhir"` | name for a custom database to create |
 | postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret The secret must contain the keys `postgres-password` (which is the password for "postgres" admin user), `password` (which is the password for the custom user to create when `auth.username` is set), and `replication-password` (which is the password for replication user). The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case. The value is evaluated as a template. |
 | postgresql.enabled | bool | `true` | enable an included PostgreSQL DB. see <https://github.com/bitnami/charts/tree/master/bitnami/postgresql> for details if set to `false`, the values under `externalDatabase` are used |
 | replicaCount | int | `1` | number of replicas to deploy |
 | resources | object | `{}` | configure the FHIR server's resource requests and limits |
+| resourcesPreset | string | `"medium"` | set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (`resources` is recommended for production). More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15> |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | securityContext.privileged | bool | `false` |  |
@@ -75,6 +81,7 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tests.automountServiceAccountToken | bool | `false` | whether the service account token should be auto-mounted for the test pods |
 | tests.resources | object | `{}` | configure the test pods resource requests and limits |
+| tests.resourcesPreset | string | `"nano"` | set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (`resources` is recommended for production). More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15> |
 | tolerations | list | `[]` | pod tolerations |
 | topologySpreadConstraints | list | `[]` | pod topology spread configuration see: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api |
 

--- a/charts/hapi-fhir-jpaserver/ci/extra-volumes-values.yaml
+++ b/charts/hapi-fhir-jpaserver/ci/extra-volumes-values.yaml
@@ -1,0 +1,11 @@
+extraVolumes:
+  - name: config-kube-root-ca
+    configMap:
+      name: kube-root-ca.crt
+      items:
+        - key: ca.crt
+          path: ca.crt
+
+extraVolumeMounts:
+  - name: config-kube-root-ca
+    mountPath: /etc/test

--- a/charts/hapi-fhir-jpaserver/templates/deployment.yaml
+++ b/charts/hapi-fhir-jpaserver/templates/deployment.yaml
@@ -31,11 +31,16 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-db-to-be-ready
-          image: docker.io/bitnami/postgresql:16.4.0-debian-12-r1@sha256:fb3d0a34e7b9f3e59442aa1fa2e6377857147c09ae754ddd5d4bb3fc0dd137da
+          image: docker.io/bitnami/postgresql:17.2.0-debian-12-r3@sha256:4de5c47eb98dd8fe09abdcbc2264984486ee8196e90902fb354f5d2ab97e8921
           imagePullPolicy: IfNotPresent
           {{- with .Values.restrictedContainerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.initContainers.resources }}
+          resources: {{- toYaml .Values.initContainers.resources | nindent 12 }}
+          {{- else if ne .Values.initContainers.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.initContainers.resourcesPreset) | nindent 12 }}
           {{- end }}
           env:
             - name: PGHOST
@@ -76,8 +81,11 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- else if ne .Values.resourcesPreset "none" }}
+          resources: {{- include "common.resources.preset" (dict "type" .Values.resourcesPreset) | nindent 12 }}
+          {{- end }}
           env:
             - name: SPRING_DATASOURCE_URL
               value: {{ include "hapi-fhir-jpaserver.database.jdbcUrl" $ }}
@@ -98,6 +106,8 @@ spec:
               value: "true"
             - name: MANAGEMENT_SERVER_PORT
               value: "8081"
+            - name: MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE
+              value: "health,prometheus"
             {{- if .Values.extraConfig }}
             - name: SPRING_CONFIG_IMPORT
               value: "/app/config/application-extra.yaml"
@@ -115,6 +125,9 @@ spec:
               mountPath: /app/config/application-extra.yaml
               readOnly: true
               subPath: application-extra.yaml
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -141,4 +154,7 @@ spec:
         - name: application-extra-config
           configMap:
             name: {{ include "hapi-fhir-jpaserver.fullname" . }}-application-config
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/hapi-fhir-jpaserver/templates/tests/test-endpoints.yaml
+++ b/charts/hapi-fhir-jpaserver/templates/tests/test-endpoints.yaml
@@ -5,11 +5,14 @@ metadata:
   labels:
     {{- include "hapi-fhir-jpaserver.labels" . | nindent 4 }}
     {{ include "hapi-fhir-jpaserver.fullname" . }}-client: "true"
+    app.kubernetes.io/component: tests
   annotations:
     "helm.sh/hook": test
 spec:
   restartPolicy: Never
   automountServiceAccountToken: {{ .Values.tests.automountServiceAccountToken }}
+  securityContext:
+    {{- toYaml .Values.tests.podSecurityContext | nindent 4 }}
   containers:
     - name: test-metadata-endpoint
       image: "{{ .Values.curl.image.registry }}/{{ .Values.curl.image.repository }}:{{ .Values.curl.image.tag }}"
@@ -19,9 +22,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tests.resources }}
-      resources:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.tests.resources }}
+      resources: {{- toYaml .Values.tests.resources | nindent 10 }}
+      {{- else if ne .Values.tests.resourcesPreset "none" }}
+      resources: {{- include "common.resources.preset" (dict "type" .Values.tests.resourcesPreset) | nindent 10 }}
       {{- end }}
       livenessProbe:
         exec:
@@ -37,9 +41,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tests.resources }}
-      resources:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.tests.resources }}
+      resources: {{- toYaml .Values.tests.resources | nindent 10 }}
+      {{- else if ne .Values.tests.resourcesPreset "none" }}
+      resources: {{- include "common.resources.preset" (dict "type" .Values.tests.resourcesPreset) | nindent 10 }}
       {{- end }}
       livenessProbe:
         exec:
@@ -55,9 +60,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tests.resources }}
-      resources:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.tests.resources }}
+      resources: {{- toYaml .Values.tests.resources | nindent 10 }}
+      {{- else if ne .Values.tests.resourcesPreset "none" }}
+      resources: {{- include "common.resources.preset" (dict "type" .Values.tests.resourcesPreset) | nindent 10 }}
       {{- end }}
       livenessProbe:
         exec:

--- a/charts/hapi-fhir-jpaserver/values.yaml
+++ b/charts/hapi-fhir-jpaserver/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- the path inside the repository
   repository: hapiproject/hapi
   # -- the image tag. As of v5.7.0, this is the `distroless` flavor by default, add `-tomcat` to use the Tomcat-based image.
-  tag: "v7.2.0@sha256:9bcafa8342b572eee248cb7c48c496863d352bbd0347e1d98ea238d09620e89b"
+  tag: "v7.6.0@sha256:4771a178e764896c83881c1b3a52bd487e53d06e1acc3653ea0db0c6f6b2b8a1"
   # -- image pullPolicy to use
   pullPolicy: IfNotPresent
 
@@ -28,8 +28,13 @@ podAnnotations: {}
 
 # -- pod security context
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  fsGroupChangePolicy: OnRootMismatch
+  runAsNonRoot: true
+  runAsGroup: 65532
+  runAsUser: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -68,6 +73,11 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+# -- set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge).
+# This is ignored if `resources` is set (`resources` is recommended for production).
+# More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15>
+resourcesPreset: "medium"
 
 # -- configure the FHIR server's resource requests and limits
 resources:
@@ -231,12 +241,39 @@ curl:
   image:
     registry: docker.io
     repository: curlimages/curl
-    tag: 8.9.1@sha256:8addc281f0ea517409209f76832b6ddc2cabc3264feb1ebbec2a2521ffad24e4
+    tag: 8.11.1@sha256:c1fe1679c34d9784c1b0d1e5f62ac0a79fca01fb6377cdd33e90473c6f9f9a69
 
 tests:
   # -- whether the service account token should be auto-mounted for the test pods
   automountServiceAccountToken: false
+  # -- set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge).
+  # This is ignored if `resources` is set (`resources` is recommended for production).
+  # More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15>
+  resourcesPreset: "nano"
   # -- configure the test pods resource requests and limits
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # @ignored
+  podSecurityContext:
+    fsGroupChangePolicy: OnRootMismatch
+    runAsNonRoot: true
+    runAsGroup: 65532
+    runAsUser: 65532
+    fsGroup: 65532
+    seccompProfile:
+      type: RuntimeDefault
+
+initContainers:
+  # -- set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge).
+  # This is ignored if `resources` is set (`resources` is recommended for production).
+  # More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15>
+  resourcesPreset: "nano"
+  # -- configure the init containers pods resource requests and limits
   resources: {}
   # limits:
   #   cpu: 100m
@@ -257,3 +294,9 @@ extraConfig:
   #         url: https://build.fhir.org/ig/hl7-eu/gravitate-health/package.tgz
   #         name: hl7.eu.fhir.gh
   #         version: 0.1.0
+
+# -- Optionally specify extra list of additional volumes
+extraVolumes: []
+
+# -- Optionally specify extra list of additional volumeMounts
+extraVolumeMounts: []


### PR DESCRIPTION
```yaml
    - kind: changed
      description: "updated postgresql sub-chart to 16.3.2"
    - kind: changed
      description: "updated curlimages/curl to 8.11.1"
    - kind: changed
      description: "updated hapiproject/hapi to 7.6.0"
    - kind: added
      description: "support for setting resource limits and requests from presets. With a default set for all containers"
    - kind: added
      description: "support for setting extra volumes and volume mounts"
    - kind: changed
      description: "set default pod security context for main and test pods"
```

Closes #757 