### PR TITLE
Externalizes more subscription parameters

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -683,31 +683,41 @@ public class AppProperties {
 		this.resource_dbhistory_enabled = resource_dbhistory_enabled;
 	}
 
-	public Boolean getPre_expand_value_sets() { return this.pre_expand_value_sets; }
+	public Boolean getPre_expand_value_sets() {
+		return this.pre_expand_value_sets;
+	}
 
 	public void setPre_expand_value_sets(Boolean pre_expand_value_sets) {
 		this.pre_expand_value_sets = pre_expand_value_sets;
 	}
 
-	public Boolean getEnable_task_pre_expand_value_sets() { return this.enable_task_pre_expand_value_sets; }
+	public Boolean getEnable_task_pre_expand_value_sets() {
+		return this.enable_task_pre_expand_value_sets;
+	}
 
 	public void setEnable_task_pre_expand_value_setss(Boolean enable_task_pre_expand_value_sets) {
 		this.enable_task_pre_expand_value_sets = enable_task_pre_expand_value_sets;
 	}
 
-	public Integer getPre_expand_value_sets_default_count() {return pre_expand_value_sets_default_count; }
+	public Integer getPre_expand_value_sets_default_count() {
+		return pre_expand_value_sets_default_count;
+	}
 
 	public void setPre_expand_value_sets_default_count(Integer pre_expand_value_sets_default_count) {
 		this.pre_expand_value_sets_default_count = pre_expand_value_sets_default_count;
 	}
 
-	public Integer getPre_expand_value_sets_max_count() { return pre_expand_value_sets_max_count; }
+	public Integer getPre_expand_value_sets_max_count() {
+		return pre_expand_value_sets_max_count;
+	}
 
 	public void setPre_expand_value_sets_max_count(Integer pre_expand_value_sets_max_count) {
 		this.pre_expand_value_sets_max_count = pre_expand_value_sets_max_count;
 	}
 
-	public Integer getMaximum_expansion_size() { return maximum_expansion_size; }
+	public Integer getMaximum_expansion_size() {
+		return maximum_expansion_size;
+	}
 
 	public void setMaximum_expansion_size(Integer maximum_expansion_size) {
 		this.maximum_expansion_size = maximum_expansion_size;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -914,6 +914,8 @@ public class AppProperties {
 		private Boolean resthook_enabled = false;
 		private Boolean websocket_enabled = false;
 		private Email email = null;
+		private Integer polling_interval_ms = null;
+		private Boolean immediately_queued = false;
 
 		public Boolean getResthook_enabled() {
 			return resthook_enabled;
@@ -937,6 +939,22 @@ public class AppProperties {
 
 		public void setEmail(Email email) {
 			this.email = email;
+		}
+
+		public Integer getPolling_interval_ms() {
+			return polling_interval_ms;
+		}
+
+		public void setPolling_interval_ms(Integer polling_interval_ms) {
+			this.polling_interval_ms = polling_interval_ms;
+		}
+
+		public Boolean getImmediately_queued() {
+			return immediately_queued;
+		}
+
+		public void setImmediately_queued(Boolean immediately_queued) {
+			this.immediately_queued = immediately_queued;
 		}
 
 		public static class Email {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -122,6 +122,18 @@ public class FhirServerConfigCommon {
 				subscriptionSettings.addSupportedSubscriptionType(
 						org.hl7.fhir.dstu2.model.Subscription.SubscriptionChannelType.WEBSOCKET);
 			}
+			if (appProperties.getSubscription().getPolling_interval_ms() != null) {
+				ourLog.info(
+						"Setting subscription polling interval to {} ms",
+						appProperties.getSubscription().getPolling_interval_ms());
+				subscriptionSettings.setSubscriptionIntervalInMs(
+						appProperties.getSubscription().getPolling_interval_ms());
+			}
+			if (appProperties.getSubscription().getImmediately_queued()) {
+				ourLog.info("Subscription update will be queued immediately");
+				subscriptionSettings.setSubscriptionChangeQueuedImmediately(
+						appProperties.getSubscription().getImmediately_queued());
+			}
 		}
 		if (appProperties.getMdm_enabled()) {
 			// MDM requires the subscription of type message

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -90,12 +90,16 @@ public class FhirServerConfigCommon {
 		}
 
 		ourLog.info("Server configured to " + (appProperties.getPre_expand_value_sets() ? "enable" : "disable")
-			+ " value set pre-expansion");
-		ourLog.info("Server configured to " + (appProperties.getEnable_task_pre_expand_value_sets() ? "enable" : "disable")
-			+ " value set pre-expansion task");
-		ourLog.info("Server configured for pre-expand value set default count of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
-		ourLog.info("Server configured for pre-expand value set max count of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
-		ourLog.info("Server configured for maximum expansion size of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
+				+ " value set pre-expansion");
+		ourLog.info(
+				"Server configured to " + (appProperties.getEnable_task_pre_expand_value_sets() ? "enable" : "disable")
+						+ " value set pre-expansion task");
+		ourLog.info("Server configured for pre-expand value set default count of "
+				+ (appProperties.getPre_expand_value_sets_default_count().toString()));
+		ourLog.info("Server configured for pre-expand value set max count of "
+				+ (appProperties.getPre_expand_value_sets_default_count().toString()));
+		ourLog.info("Server configured for maximum expansion size of "
+				+ (appProperties.getPre_expand_value_sets_default_count().toString()));
 	}
 
 	@Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -309,6 +309,8 @@ hapi:
 #    subscription:
 #      resthook_enabled: true
 #      websocket_enabled: false
+#      polling_interval_ms: 5000
+#      immediately_queued: false
 #      email:
 #        from: some@test.com
 #        host: google.com


### PR DESCRIPTION
Allows :
- to parametrize the polling interval of subscription
- to enable the setting to queue the subscription jobs immediately.

Following the change in #hapifhir/hapi-fhir/pull/6395