### PR TITLE
Expose expansion properties as configuration

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -100,6 +100,11 @@ public class AppProperties {
 	private boolean userRequestRetryVersionConflictsInterceptorEnabled = false;
 
 	private List<Integer> search_prefetch_thresholds = new ArrayList<>();
+	private Boolean pre_expand_value_sets = true;
+	private Boolean enable_task_pre_expand_value_sets = true;
+	private Integer pre_expand_value_sets_default_count = 1000;
+	private Integer pre_expand_value_sets_max_count = 1000;
+	private Integer maximum_expansion_size = 1000;
 
 	public List<String> getCustomInterceptorClasses() {
 		return custom_interceptor_classes;
@@ -676,6 +681,36 @@ public class AppProperties {
 
 	public void setResource_dbhistory_enabled(Boolean resource_dbhistory_enabled) {
 		this.resource_dbhistory_enabled = resource_dbhistory_enabled;
+	}
+
+	public Boolean getPre_expand_value_sets() { return this.pre_expand_value_sets; }
+
+	public void setPre_expand_value_sets(Boolean pre_expand_value_sets) {
+		this.pre_expand_value_sets = pre_expand_value_sets;
+	}
+
+	public Boolean getEnable_task_pre_expand_value_sets() { return this.enable_task_pre_expand_value_sets; }
+
+	public void setEnable_task_pre_expand_value_setss(Boolean enable_task_pre_expand_value_sets) {
+		this.enable_task_pre_expand_value_sets = enable_task_pre_expand_value_sets;
+	}
+
+	public Integer getPre_expand_value_sets_default_count() {return pre_expand_value_sets_default_count; }
+
+	public void setPre_expand_value_sets_default_count(Integer pre_expand_value_sets_default_count) {
+		this.pre_expand_value_sets_default_count = pre_expand_value_sets_default_count;
+	}
+
+	public Integer getPre_expand_value_sets_max_count() { return pre_expand_value_sets_max_count; }
+
+	public void setPre_expand_value_sets_max_count(Integer pre_expand_value_sets_max_count) {
+		this.pre_expand_value_sets_max_count = pre_expand_value_sets_max_count;
+	}
+
+	public Integer getMaximum_expansion_size() { return maximum_expansion_size; }
+
+	public void setMaximum_expansion_size(Integer maximum_expansion_size) {
+		this.maximum_expansion_size = maximum_expansion_size;
 	}
 
 	public static class Cors {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -88,6 +88,14 @@ public class FhirServerConfigCommon {
 		if (appProperties.getEnable_index_contained_resource() == Boolean.TRUE) {
 			ourLog.info("Indexed on contained resource enabled");
 		}
+
+		ourLog.info("Server configured to " + (appProperties.getPre_expand_value_sets() ? "enable" : "disable")
+			+ " value set pre-expansion");
+		ourLog.info("Server configured to " + (appProperties.getEnable_task_pre_expand_value_sets() ? "enable" : "disable")
+			+ " value set pre-expansion task");
+		ourLog.info("Server configured for pre-expand value set default count of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
+		ourLog.info("Server configured for pre-expand value set max count of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
+		ourLog.info("Server configured for maximum expansion size of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
 	}
 
 	@Bean
@@ -129,6 +137,12 @@ public class FhirServerConfigCommon {
 	@Bean
 	public JpaStorageSettings jpaStorageSettings(AppProperties appProperties) {
 		JpaStorageSettings jpaStorageSettings = new JpaStorageSettings();
+
+		jpaStorageSettings.setPreExpandValueSets(appProperties.getPre_expand_value_sets());
+		jpaStorageSettings.setEnableTaskPreExpandValueSets(appProperties.getEnable_task_pre_expand_value_sets());
+		jpaStorageSettings.setPreExpandValueSetsDefaultCount(appProperties.getPre_expand_value_sets_default_count());
+		jpaStorageSettings.setPreExpandValueSetsMaxCount(appProperties.getPre_expand_value_sets_max_count());
+		jpaStorageSettings.setMaximumExpansionSize(appProperties.getMaximum_expansion_size());
 
 		jpaStorageSettings.setIndexMissingFields(
 				appProperties.getEnable_index_missing_fields()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -218,6 +218,12 @@ hapi:
     #    userRequestRetryVersionConflictsInterceptorEnabled : false
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
+    #    pre_expand_value_sets: true
+    #	 enable_task_pre_expand_value_sets: true
+    #    pre_expand_value_sets_default_count: 1000
+    #    pre_expand_value_sets_max_count: 1000
+    #    maximum_expansion_size: 1000
+
     logical_urls:
       - http://terminology.hl7.org/*
       - https://terminology.hl7.org/*

--- a/src/main/resources/cds.application.yaml
+++ b/src/main/resources/cds.application.yaml
@@ -215,6 +215,13 @@ hapi:
     mdm_rules_json_location: "mdm-rules.json"
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
+
+    #    pre_expand_value_sets: true
+    #	 enable_task_pre_expand_value_sets: true
+    #    pre_expand_value_sets_default_count: 1000
+    #    pre_expand_value_sets_max_count: 1000
+    #    maximum_expansion_size: 1000
+
     logical_urls:
       - http://terminology.hl7.org/*
       - https://terminology.hl7.org/*


### PR DESCRIPTION
This is a change to expose the following properties, from JpaStorageSettings, via configuration:

private boolean myPreExpandValueSets; // pre_expand_value_sets
private int myPreExpandValueSetsDefaultCount; // pre_expand_value_sets_default_count
private int myPreExpandValueSetsMaxCount; // pre_expand_value_sets_max_count
private boolean myEnableTaskPreExpandValueSets; // enable_task_pre_expand_value_sets
private int myMaximumExpansionSize; // maximum_expansion_size