### PR TITLE
Revision Number Versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <java.version>17</java.version>
+        <hapi.fhir.jpa.server.starter.revision>1</hapi.fhir.jpa.server.starter.revision>
+    </properties>
+
     <!-- one-liner to take you to the cloud with settings form the application.yaml file: -->
     <!-- 'mvn clean package com.google.cloud.tools:jib-maven-plugin:dockerBuild -Dimage=distroless-hapi && docker run -p 8080:8080 distroless-hapi' -->
     <!--
@@ -18,12 +23,8 @@
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
-    <version>8.1.0-SNAPSHOT</version>
+    <version>${project.parent.version}-${hapi.fhir.jpa.server.starter.revision}</version>
     <packaging>war</packaging>
-
-    <properties>
-        <java.version>17</java.version>
-    </properties>
 
     <prerequisites>
         <maven>3.8.3</maven>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>
+    <version>8.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <properties>


### PR DESCRIPTION
This adds a revision number to the maven version for this project.

All releases from this point forward will be defined as a tagged commit in the master branch with a corresponding push of the project Docker images to DockerHub.

Each version of jpaserver-starter will be based on the HAPI release version it is based on, with a revision number.

**Format:**

`{HAPI-VERSION}-{REVISION-NUMBER}`

**Example:**

`8.0.0-1`

The revision number will increment when a new jpaserver-starter is released using the same HAPI version as its base.  Thus a sequence of releases based starting with HAPI 8.0.0 would look as follows:

* 8.0.0-1 (first release using HAPI 8.0.0)
* 8.0.0-2 (bug fix in jpaserver-starter)
* 8.0.0-3 (new config options provided in jpaserver-starter)

* 8.2.0-1 (first release using HAPI 8.2.0)
...


Note that there is no distinction between features or bug-fixes in the revision version.