### PR TITLE
Fixed expansion configuration options bugs

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -695,7 +695,7 @@ public class AppProperties {
 		return this.enable_task_pre_expand_value_sets;
 	}
 
-	public void setEnable_task_pre_expand_value_setss(Boolean enable_task_pre_expand_value_sets) {
+	public void setEnable_task_pre_expand_value_sets(Boolean enable_task_pre_expand_value_sets) {
 		this.enable_task_pre_expand_value_sets = enable_task_pre_expand_value_sets;
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -88,6 +88,14 @@ public class FhirServerConfigCommon {
 		if (appProperties.getEnable_index_contained_resource() == Boolean.TRUE) {
 			ourLog.info("Indexed on contained resource enabled");
 		}
+
+		ourLog.info("Server configured to " + (appProperties.getPre_expand_value_sets() ? "enable" : "disable")
+			+ " value set pre-expansion");
+		ourLog.info("Server configured to " + (appProperties.getEnable_task_pre_expand_value_sets() ? "enable" : "disable")
+			+ " value set pre-expansion task");
+		ourLog.info("Server configured for pre-expand value set default count of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
+		ourLog.info("Server configured for pre-expand value set max count of " + (appProperties.getPre_expand_value_sets_max_count().toString()));
+		ourLog.info("Server configured for maximum expansion size of " + (appProperties.getMaximum_expansion_size().toString()));
 	}
 
 	@Bean

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -90,12 +90,16 @@ public class FhirServerConfigCommon {
 		}
 
 		ourLog.info("Server configured to " + (appProperties.getPre_expand_value_sets() ? "enable" : "disable")
-			+ " value set pre-expansion");
-		ourLog.info("Server configured to " + (appProperties.getEnable_task_pre_expand_value_sets() ? "enable" : "disable")
-			+ " value set pre-expansion task");
-		ourLog.info("Server configured for pre-expand value set default count of " + (appProperties.getPre_expand_value_sets_default_count().toString()));
-		ourLog.info("Server configured for pre-expand value set max count of " + (appProperties.getPre_expand_value_sets_max_count().toString()));
-		ourLog.info("Server configured for maximum expansion size of " + (appProperties.getMaximum_expansion_size().toString()));
+				+ " value set pre-expansion");
+		ourLog.info(
+				"Server configured to " + (appProperties.getEnable_task_pre_expand_value_sets() ? "enable" : "disable")
+						+ " value set pre-expansion task");
+		ourLog.info("Server configured for pre-expand value set default count of "
+				+ (appProperties.getPre_expand_value_sets_default_count().toString()));
+		ourLog.info("Server configured for pre-expand value set max count of "
+				+ (appProperties.getPre_expand_value_sets_max_count().toString()));
+		ourLog.info("Server configured for maximum expansion size of "
+				+ (appProperties.getMaximum_expansion_size().toString()));
 	}
 
 	@Bean

--- a/src/main/resources/cds.application.yaml
+++ b/src/main/resources/cds.application.yaml
@@ -215,6 +215,13 @@ hapi:
     mdm_rules_json_location: "mdm-rules.json"
     #    local_base_urls:
     #      - https://hapi.fhir.org/baseR4
+
+    #    pre_expand_value_sets: true
+    #	 enable_task_pre_expand_value_sets: true
+    #    pre_expand_value_sets_default_count: 10000
+    #    pre_expand_value_sets_max_count: 10000
+    #    maximum_expansion_size: 10000
+
     logical_urls:
       - http://terminology.hl7.org/*
       - https://terminology.hl7.org/*


### PR DESCRIPTION
Fixes the following issues:
* The "enable_task_pre_expand-value_setss" configuration option is misspelled and is corrected in this PR to: "setEnable_task_pre_expand_value_sets".
* The logging statements for the following expansion configuration options were incorrectly reporting the value of "pre_expand_value_sets_default_count" rather than their own corresponding value:
    * "pre_expand_value_sets_max_count"
    * "maximum_expansion_size"