### PR TITLE
fix: set default value for request_tenant_partitioning_mode to true to support easy default partitioning

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -855,7 +855,7 @@ public class AppProperties {
 		private Boolean database_partition_mode_enabled = false;
 		private Boolean patient_id_partitioning_mode = false;
 		private Integer default_partition_id = 0;
-		private boolean request_tenant_partitioning_mode;
+		private boolean request_tenant_partitioning_mode = true;
 
 		public boolean isRequest_tenant_partitioning_mode() {
 			return request_tenant_partitioning_mode;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -237,6 +237,7 @@ hapi:
     #      allow_references_across_partitions: false
     #      partitioning_include_in_search_hashes: false
     #      conditional_create_duplicate_identifiers_enabled: false
+    #      request_tenant_partitioning_mode: true
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-


### PR DESCRIPTION
## Enable request_tenant_partitioning_mode by default in HAPI FHIR JPA Starter

### Description

This PR updates the `hapi-fhir-jpaserver-starter` to set `request_tenant_partitioning_mode = true` by default in AppProperties & `application.yaml`.  
This change ensures that multi-tenancy is enabled using the tenant ID in the request URL base, which is handled by the following logic:

```java
if (myAppProperties.getPartitioning().getRequest_tenant_partitioning_mode() == Boolean.TRUE) {
	ourLog.info("Partitioning mode enabled in: Request tenant partitioning mode");
	myRestfulServer.registerInterceptor(new RequestTenantPartitionInterceptor());
	myRestfulServer.setTenantIdentificationStrategy(new UrlBaseTenantIdentificationStrategy());
}
