### PR TITLE
feat: add support for relaxed query characters in Tomcat configuration

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,9 @@ server:
   #  servlet:
   #    context-path: /example/path
   port: 8080
+  tomcat:
+    # allow | as a separator in the URL
+    relaxed-query-chars: "|"
 #Adds the option to go to eg. http://localhost:8080/actuator/health for seeing the running configuration
 #see https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints
 management:


### PR DESCRIPTION
This pull request includes a configuration update to the `application.yaml` file, enhancing the server settings for better URL handling.

### Server Configuration Updates:
* Added a `tomcat` configuration block under `server` to allow the `|` character as a separator in URLs by setting `relaxed-query-chars`. This improves the flexibility of query parameters in the application. 