### PR TITLE
Fixed bug in setting of jpaStorageSettings pre-expansion settings

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -156,8 +156,8 @@ public class FhirServerConfigCommon {
 
 		jpaStorageSettings.setPreExpandValueSets(appProperties.getPre_expand_value_sets());
 		jpaStorageSettings.setEnableTaskPreExpandValueSets(appProperties.getEnable_task_pre_expand_value_sets());
-		jpaStorageSettings.setPreExpandValueSetsDefaultCount(appProperties.getPre_expand_value_sets_default_count());
 		jpaStorageSettings.setPreExpandValueSetsMaxCount(appProperties.getPre_expand_value_sets_max_count());
+		jpaStorageSettings.setPreExpandValueSetsDefaultCount(appProperties.getPre_expand_value_sets_default_count());
 		jpaStorageSettings.setMaximumExpansionSize(appProperties.getMaximum_expansion_size());
 
 		jpaStorageSettings.setIndexMissingFields(


### PR DESCRIPTION
Because of the way the setters in JpaStorageSettings are defined for PreExpandValueSetsMaxCount and PreExpandValueSetsDefaultCount, if PreExpandValueSetsDefaultCount is set before PreExpandValueSetsMaxCount, PreExpandValueSetsDefaultCount will be reset to its default value by the setter for PreExpandValueSetsMaxCount.
This does not do anything to change the setters, but switches the order in which they are called from FhirServerConfigCommon.