### PR TITLE
process jpa properties set as env variables

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/util/EnvironmentHelper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/util/EnvironmentHelper.java
@@ -40,7 +40,7 @@ public class EnvironmentHelper {
 			properties.put(strippedKey, entry.getValue().toString());
 		}
 
-		// also check for JPA properterties set as environment variables, this is slightly hacky and doesn't cover all
+		// also check for JPA properties set as environment variables, this is slightly hacky and doesn't cover all
 		// the naming conventions Springboot allows
 		// but there doesn't seem to be a better/deterministic way to get these properties when they are set as ENV
 		// variables and this at least provides

--- a/src/main/java/ca/uhn/fhir/jpa/starter/util/EnvironmentHelper.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/util/EnvironmentHelper.java
@@ -40,6 +40,19 @@ public class EnvironmentHelper {
 			properties.put(strippedKey, entry.getValue().toString());
 		}
 
+		// also check for JPA properterties set as environment variables, this is slightly hacky and doesn't cover all
+		// the naming conventions Springboot allows
+		// but there doesn't seem to be a better/deterministic way to get these properties when they are set as ENV
+		// variables and this at least provides
+		// a way to set them (in a docker container, for instance)
+		Map<String, Object> jpaPropsEnv = getPropertiesStartingWith(environment, "SPRING_JPA_PROPERTIES");
+		for (Map.Entry<String, Object> entry : jpaPropsEnv.entrySet()) {
+			String strippedKey = entry.getKey().replace("SPRING_JPA_PROPERTIES_", "");
+			strippedKey = strippedKey.replaceAll("_", ".");
+			strippedKey = strippedKey.toLowerCase();
+			properties.put(strippedKey, entry.getValue().toString());
+		}
+
 		// Spring Boot Autoconfiguration defaults
 		properties.putIfAbsent(AvailableSettings.SCANNER, "org.hibernate.boot.archive.scan.internal.DisabledScanner");
 		properties.putIfAbsent(


### PR DESCRIPTION
see : https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/804

Summary: 
This PR is intended to address an issue where properties "spring.jpa.properties.*" are not being picked up when set as environment variables using Springboot's relaxed binding rules for environment variables (i.e. SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT). 

The docker-compose.yml file in the project currently doesn't work. (Not sure what changed and why it stopped working). 
In debugging that, I attempted to set the SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT as an env var in the docker-compose.yml file to fix it, and then discovered that the dialect was not being picked up. Hence this PR. 
