### PR TITLE
feat: add timeout comment for validate operation in plain_server.http

### DIFF
--- a/src/test/smoketest/plain_server.http
+++ b/src/test/smoketest/plain_server.http
@@ -206,6 +206,7 @@ GET http://{{host}}/fhir/Patient/{{batch_patient_id}}/$everything
 
 ### Extended Operations - validate
 # https://hapifhir.io/hapi-fhir/docs/server_plain/rest_operations_operations.html
+# @timeout 180   # wait up to 2 minutes for the validate response
 POST http://{{host}}/fhir/Patient/{{batch_patient_id}}/$validate
 
 > {%


### PR DESCRIPTION
This pull request introduces a timeout (120s) configuration for the `validate` operation in the `plain_server.http` smoke test file. 

* [`src/test/smoketest/plain_server.http`](diffhunk://#diff-c0cf111e04ed2f38469fb078a0fda5521c8d908794adb999ed3d6b1db0c1a5a4R209): Added a `@timeout` directive to specify a maximum wait time of 2 minutes for the `$validate` operation response.