### PR TITLE
feat: add support to enable search index full text

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -34,6 +34,7 @@ public class AppProperties {
 	private Boolean mdm_enabled = false;
 	private String mdm_rules_json_location = "mdm-rules.json";
 	private boolean advanced_lucene_indexing = false;
+	private boolean search_index_full_text_enabled = false;
 	private boolean enable_index_of_type = false;
 	private Boolean allow_cascading_deletes = false;
 	private Boolean allow_contains_searches = true;
@@ -282,6 +283,14 @@ public class AppProperties {
 
 	public void setAdvanced_lucene_indexing(boolean theAdvanced_lucene_indexing) {
 		advanced_lucene_indexing = theAdvanced_lucene_indexing;
+	}
+
+	public boolean getSearch_index_full_text_enabled() {
+		return this.search_index_full_text_enabled;
+	}
+
+	public void setSearch_index_full_text_enabled(boolean theSearch_index_full_text_enabled) {
+		search_index_full_text_enabled = theSearch_index_full_text_enabled;
 	}
 
 	public Boolean getAllow_cascading_deletes() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -201,6 +201,7 @@ public class FhirServerConfigCommon {
 
 		jpaStorageSettings.setFilterParameterEnabled(appProperties.getFilter_search_enabled());
 		jpaStorageSettings.setHibernateSearchIndexSearchParams(appProperties.getAdvanced_lucene_indexing());
+		jpaStorageSettings.setHibernateSearchIndexFullText(appProperties.getSearch_index_full_text_enabled());
 		jpaStorageSettings.setTreatBaseUrlsAsLocal(new HashSet<>(appProperties.getLocal_base_urls()));
 		jpaStorageSettings.setTreatReferencesAsLogical(new HashSet<>(appProperties.getLogical_urls()));
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -200,6 +200,7 @@ hapi:
     ###  !!Extended Lucene/Elasticsearch Indexing is still a experimental feature, expect some features (e.g. _total=accurate) to not work as expected!!
     ###  more information here: https://hapifhir.io/hapi-fhir/docs/server_jpa/elastic.html
     advanced_lucene_indexing: false
+    search_index_full_text_enabled: false
     bulk_export_enabled: false
     bulk_import_enabled: false
     #    language_search_parameter_enabled: true

--- a/src/main/resources/cds.application.yaml
+++ b/src/main/resources/cds.application.yaml
@@ -196,6 +196,7 @@ hapi:
     ###  !!Extended Lucene/Elasticsearch Indexing is still a experimental feature, expect some features (e.g. _total=accurate) to not work as expected!!
     ###  more information here: https://hapifhir.io/hapi-fhir/docs/server_jpa/elastic.html
     advanced_lucene_indexing: false
+    search_index_full_text_enabled: false
     bulk_export_enabled: false
     bulk_import_enabled: false
     #    language_search_parameter_enabled: true

--- a/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
@@ -52,6 +52,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     "hapi.fhir.lastn_enabled=true",
 	 "hapi.fhir.store_resource_in_lucene_index_enabled=true",
 	 "hapi.fhir.advanced_lucene_indexing=true",
+	 "hapi.fhir.search_index_full_text_enabled=true",
 
     "elasticsearch.enabled=true",
 	  "hapi.fhir.cr_enabled=false",

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -129,6 +129,7 @@ hapi:
     ###  !!Extended Lucene/Elasticsearch Indexing is still a experimental feature, expect some features (e.g. _total=accurate) to not work as expected!!
     ###  more information here: https://hapifhir.io/hapi-fhir/docs/server_jpa/elastic.html
     advanced_lucene_indexing: false
+    search_index_full_text_enabled: false
     #    enforce_referential_integrity_on_delete: false
     # This is an experimental feature, and does not fully support _total and other FHIR features.
     #    enforce_referential_integrity_on_delete: false


### PR DESCRIPTION
Add support to enable search index full text disabled by default https://github.com/hapifhir/hapi-fhir/pull/6426. This was enabled by default and non configurable for version 7.6.0 and older and disabled by default from version 8.0.0 and newer which can be enabled
Fixes: #807