### PR TITLE
ci: remove success message from formatting check

### DIFF
--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -20,9 +20,12 @@ jobs:
       - name: spotless:check
         run: mvn spotless:check
       -  uses: mshick/add-pr-comment@v2
-         if: always()
+         # Only run if the previous step failed
+         if: failure() && steps.spotless_check.outcome == 'failure'
          with:
            proxy-url: https://slack-bots.azure.smilecdr.com/robogary/github
+           message-success: |
+             Formatting check succeeded! This should never run, because the step is skipped on workflow success.
            message-failure: |
              **This Pull Request has failed the formatting check**
              


### PR DESCRIPTION
The workflow succeeds giving a green check-mark next to the commit id. 

Perhaps writing a comment each time is more distracting than helpful?

<img width="945" height="247" alt="image" src="https://github.com/user-attachments/assets/fcf35ce4-8d34-42f9-a56b-9d597b22c0fc" />

E.g.: https://github.com/hapifhir/hapi-fhir-jpaserver-starter/pull/856