### PR TITLE
Switched to the bitnamilegacy image repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /app && cp /tmp/hapi-fhir-jpaserver-starter/target/ROOT.war /app/main.
 
 ########### bitnami tomcat version is suitable for debugging and comes with a shell
 ########### it can be built using eg. `docker build --target tomcat .`
-FROM bitnami/tomcat:10.1 AS tomcat
+FROM docker.io/bitnamilegacy/tomcat:10.1.43-debian-12-r0 AS tomcat
 
 USER root
 RUN rm -rf /opt/bitnami/tomcat/webapps/ROOT && \

--- a/charts/hapi-fhir-jpaserver/Chart.lock
+++ b/charts/hapi-fhir-jpaserver/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.7.11
+  version: 16.7.27
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 2.31.3
-digest: sha256:e8b5591d28c8b420a68c1bef3ac8530f47c0c9c5d22fddec3c73f45ae5ba615a
-generated: "2025-06-16T13:22:01.211160104+02:00"
+digest: sha256:4ac06ee8266b694791c14eaef2e0f19a5714ebe4bd19b1bcb4bc6069d8fab482
+generated: "2025-09-22T11:26:51.06616649+02:00"

--- a/charts/hapi-fhir-jpaserver/Chart.yaml
+++ b/charts/hapi-fhir-jpaserver/Chart.yaml
@@ -7,14 +7,14 @@ sources:
   - https://github.com/hapifhir/hapi-fhir-jpaserver-starter
 dependencies:
   - name: postgresql
-    version: 16.7.11
+    version: 16.7.27
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: postgresql.enabled
   - name: common
     repository: oci://registry-1.docker.io/bitnamicharts
     version: 2.31.3
 appVersion: 8.2.0
-version: 0.20.1
+version: 0.21.0
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/containsSecurityUpdates: "false"
@@ -27,4 +27,4 @@ annotations:
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
     - kind: changed
-      description: "fixed typo in README.md"
+      description: "Use the bitnamilegacy repos for the images. See <https://github.com/bitnami/containers/issues/83267>."

--- a/charts/hapi-fhir-jpaserver/README.md
+++ b/charts/hapi-fhir-jpaserver/README.md
@@ -1,6 +1,6 @@
 # HAPI FHIR JPA Server Starter Helm Chart
 
-![Version: 0.20.1](https://img.shields.io/badge/Version-0.20.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.2.0](https://img.shields.io/badge/AppVersion-8.2.0-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.2.0](https://img.shields.io/badge/AppVersion-8.2.0-informational?style=flat-square)
 
 This helm chart will help you install the HAPI FHIR JPA Server in a Kubernetes environment.
 
@@ -16,7 +16,7 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | Repository | Name | Version |
 |------------|------|---------|
 | oci://registry-1.docker.io/bitnamicharts | common | 2.31.3 |
-| oci://registry-1.docker.io/bitnamicharts | postgresql | 16.7.11 |
+| oci://registry-1.docker.io/bitnamicharts | postgresql | 16.7.27 |
 
 ## Values
 
@@ -62,6 +62,7 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | postgresql.auth.database | string | `"fhir"` | name for a custom database to create |
 | postgresql.auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret The secret must contain the keys `postgres-password` (which is the password for "postgres" admin user), `password` (which is the password for the custom user to create when `auth.username` is set), and `replication-password` (which is the password for replication user). The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case. The value is evaluated as a template. |
 | postgresql.enabled | bool | `true` | enable an included PostgreSQL DB. see <https://github.com/bitnami/charts/tree/master/bitnami/postgresql> for details if set to `false`, the values under `externalDatabase` are used |
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |
 | replicaCount | int | `1` | number of replicas to deploy |
 | resources | object | `{}` | configure the FHIR server's resource requests and limits |
 | resourcesPreset | string | `"medium"` | set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (`resources` is recommended for production). More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15> |
@@ -84,7 +85,7 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | tests.resourcesPreset | string | `"nano"` | set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (`resources` is recommended for production). More information: <https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15> |
 | tolerations | list | `[]` | pod tolerations |
 | topologySpreadConstraints | list | `[]` | pod topology spread configuration see: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#api |
-| waitForDatabaseInitContainer.image | object | `{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"bitnami/postgresql","tag":"17.5.0-debian-12-r11@sha256:ac8dd0d6512c4c5fb146c16b1c5f05862bd5f600d73348506ab4252587e7fcc6"}` | image to use for the init container which waits until the database is ready to accept connections |
+| waitForDatabaseInitContainer.image | object | `{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"17.6.0-debian-12-r4@sha256:926356130b77d5742d8ce605b258d35db9b62f2f8fd1601f9dbaef0c8a710a8d"}` | image to use for the init container which waits until the database is ready to accept connections |
 
 ## Development
 

--- a/charts/hapi-fhir-jpaserver/values.yaml
+++ b/charts/hapi-fhir-jpaserver/values.yaml
@@ -114,11 +114,19 @@ topologySpreadConstraints:
   #       app.kubernetes.io/instance: hapi-fhir-jpaserver
   #       app.kubernetes.io/name: hapi-fhir-jpaserver
 
+# @ignored
+# used by the bitnami sub-chart. Allowing it allows for overrding the image repository.
+global:
+  security:
+    allowInsecureImages: true
+
 postgresql:
   # -- enable an included PostgreSQL DB.
   # see <https://github.com/bitnami/charts/tree/master/bitnami/postgresql> for details
   # if set to `false`, the values under `externalDatabase` are used
   enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
     # -- name for a custom database to create
     database: "fhir"
@@ -306,6 +314,6 @@ waitForDatabaseInitContainer:
   # is ready to accept connections
   image:
     registry: docker.io
-    repository: bitnami/postgresql
-    tag: 17.5.0-debian-12-r11@sha256:ac8dd0d6512c4c5fb146c16b1c5f05862bd5f600d73348506ab4252587e7fcc6
+    repository: bitnamilegacy/postgresql
+    tag: 17.6.0-debian-12-r4@sha256:926356130b77d5742d8ce605b258d35db9b62f2f8fd1601f9dbaef0c8a710a8d
     pullPolicy: IfNotPresent


### PR DESCRIPTION
As per: https://github.com/bitnami/containers/issues/83267 soon the bitnami images won't be available. As a temporary workaround I switched to the bitnamilegacy repo which no longer receives updates.

Long-term we should consider switching the tomcat image to the official one and use a different postgres sub-chart. Personally, I migrated several charts to use <https://github.com/CloudPirates-io/helm-charts/tree/main/charts/postgres> which could be an option for here as well.