### PR TITLE
make thread count configurable

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -118,6 +118,8 @@ public class AppProperties {
 	private Map<String, RemoteSystem> remote_terminology_service = null;
 	private Boolean match_url_cache_enabled = false;
 	private Boolean index_storage_optimized = false;
+	private Integer reindex_thread_count = null;
+	private Integer expunge_thread_count = null;
 
 	public List<String> getCustomInterceptorClasses() {
 		return custom_interceptor_classes;
@@ -783,6 +785,24 @@ public class AppProperties {
 
 	public void setIndex_storage_optimized(boolean theIndex_storage_optimized) {
 		index_storage_optimized = theIndex_storage_optimized;
+	}
+
+
+
+	public Integer getReindex_thread_count() {
+		return reindex_thread_count;
+	}
+
+	public void setReindex_thread_count(Integer reindex_thread_count) {
+		this.reindex_thread_count = reindex_thread_count;
+	}
+
+	public Integer getExpunge_thread_count() {
+		return expunge_thread_count;
+	}
+
+	public void setExpunge_thread_count(Integer expunge_thread_count) {
+		this.expunge_thread_count = expunge_thread_count;
 	}
 
 	public JpaStorageSettings.StoreMetaSourceInformationEnum getStore_meta_source_information() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -787,8 +787,6 @@ public class AppProperties {
 		index_storage_optimized = theIndex_storage_optimized;
 	}
 
-
-
 	public Integer getReindex_thread_count() {
 		return reindex_thread_count;
 	}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -286,11 +286,15 @@ public class FhirServerConfigCommon {
 		// Configure thread counts for reindex and expunge operations
 		if (appProperties.getReindex_thread_count() != null) {
 			jpaStorageSettings.setReindexThreadCount(appProperties.getReindex_thread_count());
-			ourLog.info("Server configured to use {} threads for reindex operations", appProperties.getReindex_thread_count());
+			ourLog.info(
+					"Server configured to use {} threads for reindex operations",
+					appProperties.getReindex_thread_count());
 		}
 		if (appProperties.getExpunge_thread_count() != null) {
 			jpaStorageSettings.setExpungeThreadCount(appProperties.getExpunge_thread_count());
-			ourLog.info("Server configured to use {} threads for expunge operations", appProperties.getExpunge_thread_count());
+			ourLog.info(
+					"Server configured to use {} threads for expunge operations",
+					appProperties.getExpunge_thread_count());
 		}
 
 		return jpaStorageSettings;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -282,6 +282,17 @@ public class FhirServerConfigCommon {
 
 		jpaStorageSettings.setIndexOnContainedResources(appProperties.getEnable_index_contained_resource());
 		jpaStorageSettings.setIndexIdentifierOfType(appProperties.getEnable_index_of_type());
+
+		// Configure thread counts for reindex and expunge operations
+		if (appProperties.getReindex_thread_count() != null) {
+			jpaStorageSettings.setReindexThreadCount(appProperties.getReindex_thread_count());
+			ourLog.info("Server configured to use {} threads for reindex operations", appProperties.getReindex_thread_count());
+		}
+		if (appProperties.getExpunge_thread_count() != null) {
+			jpaStorageSettings.setExpungeThreadCount(appProperties.getExpunge_thread_count());
+			ourLog.info("Server configured to use {} threads for expunge operations", appProperties.getExpunge_thread_count());
+		}
+
 		return jpaStorageSettings;
 	}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -279,6 +279,11 @@ hapi:
     # filter_search_enabled: true
     # graphql_enabled: true
 
+    # Thread pool configuration for maintenance operations
+    # Defaults to Runtime.getRuntime().availableProcessors() if not specified
+    # reindex_thread_count: 4        # Number of threads to use for reindex operations
+    # expunge_thread_count: 4        # Number of threads to use for expunge operations
+
     # -------------------------------------------------------------------------------
     # G. Narrative & Validation
     # -------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces configurable thread counts for reindex and expunge maintenance operations in the FHIR server. These changes allow administrators to control the parallelism of these operations via new properties, improving flexibility and potential performance tuning.

**Configuration enhancements:**

* Added `reindex_thread_count` and `expunge_thread_count` properties to the `AppProperties` class, along with their getters and setters, allowing these values to be set via configuration. [[1]](diffhunk://#diff-79251bbeac3bb7f417a707bbda464fdfb2394f40bd88e43a9f5472e0ed351c83R121-R122) [[2]](diffhunk://#diff-79251bbeac3bb7f417a707bbda464fdfb2394f40bd88e43a9f5472e0ed351c83R790-R805)
* Updated `application.yaml` to document the new configuration options, including comments on their defaults and usage.

**Operational improvements:**

* Modified `FhirServerConfigCommon.java` to read the new thread count properties and apply them to the `JpaStorageSettings` if specified, including logging the configured values for visibility.