### PR TITLE
Adding custom-bean-packages property in application.yaml

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -359,7 +359,7 @@ hapi:
     # -------------------------------------------------------------------------------
     # comma-separated package names, will be @ComponentScan'ed by Spring to allow for creating custom Spring beans
 
-    # custom-provider-classes:
+    # custom-bean-packages:
     # custom-interceptor-classes:
     # custom-provider-classes:
     


### PR DESCRIPTION
Adding the missing custom-bean-packages property in application.yaml and removing the duplicate custom-provider-classes property

Fix for https://github.com/hapifhir/hapi-fhir-jpaserver-starter/issues/885