### PR TITLE
HAPI 8.8.0 Release Tracking Branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <properties>
         <java.version>17</java.version>
         <hapi.fhir.jpa.server.starter.revision>1</hapi.fhir.jpa.server.starter.revision>
-        <clinical-reasoning.version>4.2.0</clinical-reasoning.version>
+        <clinical-reasoning.version>4.4.0</clinical-reasoning.version>
 
         <!-- Plugins Versions -->
         <maven.failsafe.version>3.5.4</maven.failsafe.version>


### PR DESCRIPTION
This branch updates jpaserver-starter to HAPI 8.8.0 and also includes the following version changes:

clinical-reasoning 4.2.0 -> 4.4.0
logback 1.5.19 -> 1.5.25

It also includes minor improvements to the pom.xml structure and inheritance from HAPI.