### PR TITLE
Add TestContainerHelper for simplified integration testing

### DIFF
--- a/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/ElasticsearchLastNR4IT.java
@@ -3,21 +3,18 @@ package ca.uhn.fhir.jpa.starter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.jpa.search.lastn.ElasticsearchRestClientFactory;
 import ca.uhn.fhir.jpa.search.lastn.ElasticsearchSvcImpl;
+import ca.uhn.fhir.jpa.starter.common.TestContainerHelper;
 import ca.uhn.fhir.jpa.starter.elastic.ElasticsearchBootSvcImpl;
-import ca.uhn.fhir.jpa.test.config.TestElasticsearchContainerHelper;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
-import java.io.IOException;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch.indices.IndexSettings;
-import jakarta.annotation.PreDestroy;
 import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.DateTimeType;
@@ -26,91 +23,47 @@ import org.hl7.fhir.r4.model.Observation;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@ExtendWith(SpringExtension.class)
 @Testcontainers
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class, ElasticsearchLastNR4IT.TestConfig.class}, properties =
-  {
-    "spring.datasource.url=jdbc:h2:mem:dbr4",
-    "hapi.fhir.fhir_version=r4",
-    "hapi.fhir.lastn_enabled=true",
-	 "hapi.fhir.store_resource_in_lucene_index_enabled=true",
-	 "hapi.fhir.advanced_lucene_indexing=true",
-	 "hapi.fhir.search_index_full_text_enabled=true",
-	  "hapi.fhir.cr_enabled=false",
-    // Because the port is set randomly, we will set the rest_url using the Initializer.
-    // "elasticsearch.rest_url='http://localhost:9200'",
-
-	  "spring.elasticsearch.uris=http://localhost:9200",
-     "spring.elasticsearch.username=elastic",
-     "spring.elasticsearch.password=changeme",
-	  "spring.main.allow-bean-definition-overriding=true",
-	  "spring.jpa.properties.hibernate.search.enabled=true",
-	  "spring.jpa.properties.hibernate.search.backend.type=elasticsearch",
-	  "spring.jpa.properties.hibernate.search.backend.hosts=localhost:9200",
-	  "spring.jpa.properties.hibernate.search.backend.protocol=http",
-	  "spring.jpa.properties.hibernate.search.backend.analysis.configurer=ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiElasticsearchAnalysisConfigurer"
-  })
-@ContextConfiguration(initializers = ElasticsearchLastNR4IT.Initializer.class)
+@TestPropertySource(locations = "classpath:test-elasticsearch-lastn.yaml")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class})
 class ElasticsearchLastNR4IT {
   private IGenericClient ourClient;
-  private FhirContext ourCtx;
 
   @Container
-  public static ElasticsearchContainer embeddedElastic = TestElasticsearchContainerHelper.getEmbeddedElasticSearch();
+  private static final ElasticsearchContainer ELASTICSEARCH = TestContainerHelper.newElasticsearchContainer()
+    // Set index defaults to handle HAPI FHIR's MAX_SUBSCRIPTION_RESULTS (50000)
+    .withEnv("indices.query.bool.max_clause_count", "50000");
+
+  @DynamicPropertySource
+  static void registerElasticsearchProperties(DynamicPropertyRegistry registry) {
+    TestContainerHelper.registerElasticsearchProperties(registry, ELASTICSEARCH);
+    // Also register spring.elasticsearch.uris for ElasticConfigCondition to enable ElasticsearchBootSvcImpl
+    registry.add("spring.elasticsearch.uris", () -> TestContainerHelper.getElasticsearchHttpUrl(ELASTICSEARCH));
+  }
 
   @Autowired
   private ElasticsearchBootSvcImpl myElasticsearchSvc;
-
-  @BeforeAll
-  public static void beforeClass() throws IOException {
-	  //Given
-	  ElasticsearchClient elasticsearchHighLevelRestClient = ElasticsearchRestClientFactory.createElasticsearchHighLevelRestClient(
-		  "http", embeddedElastic.getHost() + ":" + embeddedElastic.getMappedPort(9200), "", "");
-
-	  /* As of 2023-08-10, HAPI FHIR sets SubscriptionConstants.MAX_SUBSCRIPTION_RESULTS to 50000
-	  		which is in excess of elastic's default max_result_window. If MAX_SUBSCRIPTION_RESULTS is changed
-	  		to a value <= 10000, the following will no longer be necessary. - dotasek
-	  */
-
-	  elasticsearchHighLevelRestClient.indices().putTemplate(t->{
-		  t.name("hapi_fhir_template");
-		  t.indexPatterns("*");
-		  t.settings(new IndexSettings.Builder().maxNgramDiff(50).maxResultWindow(50000).build());
-		  return t;
-	  });
-  }
-
-  @PreDestroy
-  public void stop() {
-    embeddedElastic.stop();
-  }
 
   @LocalServerPort
   private int port;
 
   @Test
   void testLastN() throws IOException, InterruptedException {
-	 Thread.sleep(2000);
+    Thread.sleep(2000);
 
     Patient pt = new Patient();
     pt.addName().setFamily("Lastn").addGiven("Arthur");
@@ -119,9 +72,8 @@ class ElasticsearchLastNR4IT {
     Observation obs = new Observation();
     obs.getSubject().setReferenceElement(id);
     String observationCode = "testobservationcode";
-    String codeSystem = "http://testobservationcodesystem";
 
-    obs.getCode().addCoding().setCode(observationCode).setSystem(codeSystem);
+    obs.getCode().addCoding().setCode(observationCode).setSystem("http://testobservationcodesystem");
     obs.setValue(new StringType(observationCode));
 
     Date effectiveDtm = new GregorianCalendar().getTime();
@@ -142,38 +94,11 @@ class ElasticsearchLastNR4IT {
   }
 
   @BeforeEach
-  void beforeEach() throws IOException {
-
-    ourCtx = FhirContext.forR4();
-    ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
-    ourCtx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
-    String ourServerBase = "http://localhost:" + port + "/fhir/";
-    ourClient = ourCtx.newRestfulGenericClient(ourServerBase);
+  void beforeEach() {
+    FhirContext ctx = FhirContext.forR4();
+    ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+    ctx.getRestfulClientFactory().setSocketTimeout((int) Duration.ofMinutes(20).toMillis());
+    ourClient = ctx.newRestfulGenericClient("http://localhost:" + port + "/fhir/");
     ourClient.registerInterceptor(new LoggingInterceptor(true));
-
-  }
-
-  @Configuration
-  static class TestConfig {
-    @Bean
-    public ElasticsearchClient elasticsearchClient() throws IOException {
-      return ElasticsearchRestClientFactory.createElasticsearchHighLevelRestClient(
-        "http", embeddedElastic.getHost() + ":" + embeddedElastic.getMappedPort(9200), "", "");
-    }
-  }
-
-  static class Initializer
-    implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-
-    @Override
-    public void initialize(
-      ConfigurableApplicationContext configurableApplicationContext) {
-      // Since the port is dynamically generated, replace the URL with one that has the correct port
-      TestPropertyValues.of("spring.elasticsearch.uris=http://" + embeddedElastic.getHost() + ":" + embeddedElastic.getMappedPort(9200))
-        .applyTo(configurableApplicationContext.getEnvironment());
-		 TestPropertyValues.of("spring.jpa.properties.hibernate.search.backend.hosts=" + embeddedElastic.getHost() +":" + embeddedElastic.getMappedPort(9200))
-			 .applyTo(configurableApplicationContext.getEnvironment());
-    }
-
   }
 }

--- a/src/test/java/ca/uhn/fhir/jpa/starter/common/TestContainerHelper.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/common/TestContainerHelper.java
@@ -1,0 +1,164 @@
+package ca.uhn.fhir.jpa.starter.common;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+/**
+ * Helper class for creating and configuring Testcontainers used in integration tests.
+ * <p>
+ * This class provides factory methods for creating pre-configured containers and utility methods
+ * for registering container properties with Spring's {@link DynamicPropertyRegistry}.
+ * </p>
+ *
+ * <h2>Usage Example:</h2>
+ * <pre>{@code
+ * @Testcontainers
+ * @SpringBootTest
+ * class MyIntegrationTest {
+ *
+ *     @Container
+ *     private static final PostgreSQLContainer<?> POSTGRES = TestContainerHelper.newPostgresContainer();
+ *
+ *     @Container
+ *     private static final ElasticsearchContainer ELASTICSEARCH = TestContainerHelper.newElasticsearchContainer();
+ *
+ *     @DynamicPropertySource
+ *     static void registerProperties(DynamicPropertyRegistry registry) {
+ *         TestContainerHelper.registerPostgresProperties(registry, POSTGRES);
+ *         TestContainerHelper.registerElasticsearchProperties(registry, ELASTICSEARCH);
+ *     }
+ * }
+ * }</pre>
+ */
+public final class TestContainerHelper {
+
+	// Container image versions
+	private static final String POSTGRES_IMAGE = "postgres:16-alpine";
+	private static final String ELASTICSEARCH_IMAGE = "elasticsearch:8.19.10";
+
+	// Default PostgreSQL configuration
+	private static final String DEFAULT_DATABASE_NAME = "hapi";
+	private static final String DEFAULT_USERNAME = "fhiruser";
+	private static final String DEFAULT_PASSWORD = "fhirpass";
+
+	// Hibernate dialect for HAPI FHIR with PostgreSQL
+	private static final String HAPI_POSTGRES_DIALECT = "ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect";
+
+	private TestContainerHelper() {
+		// Utility class - prevent instantiation
+	}
+
+	/**
+	 * Creates a new PostgreSQL container with default HAPI FHIR configuration.
+	 * <p>
+	 * The container is configured with:
+	 * <ul>
+	 *   <li>Image: postgres:16-alpine</li>
+	 *   <li>Database name: hapi</li>
+	 *   <li>Username: fhiruser</li>
+	 *   <li>Password: fhirpass</li>
+	 * </ul>
+	 *
+	 * @return a new pre-configured PostgreSQL container
+	 */
+	public static PostgreSQLContainer<?> newPostgresContainer() {
+		return new PostgreSQLContainer<>(POSTGRES_IMAGE)
+			.withDatabaseName(DEFAULT_DATABASE_NAME)
+			.withUsername(DEFAULT_USERNAME)
+			.withPassword(DEFAULT_PASSWORD);
+	}
+
+	/**
+	 * Creates a new Elasticsearch container with default configuration for HAPI FHIR.
+	 * <p>
+	 * The container is configured with:
+	 * <ul>
+	 *   <li>Image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0</li>
+	 *   <li>Security disabled (xpack.security.enabled=false)</li>
+	 *   <li>Single-node discovery mode</li>
+	 *   <li>JVM heap: 512MB min/max</li>
+	 * </ul>
+	 *
+	 * @return a new pre-configured Elasticsearch container
+	 */
+	public static ElasticsearchContainer newElasticsearchContainer() {
+		return new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+			.withEnv("xpack.security.enabled", "false")
+			.withEnv("discovery.type", "single-node")
+			.withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
+	}
+
+	/**
+	 * Registers PostgreSQL container properties with Spring's DynamicPropertyRegistry.
+	 * <p>
+	 * Registers the following properties:
+	 * <ul>
+	 *   <li>spring.datasource.url</li>
+	 *   <li>spring.datasource.username</li>
+	 *   <li>spring.datasource.password</li>
+	 *   <li>spring.datasource.driver-class-name</li>
+	 *   <li>spring.jpa.properties.hibernate.dialect</li>
+	 * </ul>
+	 *
+	 * @param registry  the Spring dynamic property registry
+	 * @param container the PostgreSQL container
+	 */
+	public static void registerPostgresProperties(DynamicPropertyRegistry registry, PostgreSQLContainer<?> container) {
+		registry.add("spring.datasource.url", container::getJdbcUrl);
+		registry.add("spring.datasource.username", container::getUsername);
+		registry.add("spring.datasource.password", container::getPassword);
+		registry.add("spring.datasource.driver-class-name", container::getDriverClassName);
+		registry.add("spring.jpa.properties.hibernate.dialect", () -> HAPI_POSTGRES_DIALECT);
+	}
+
+	/**
+	 * Registers Elasticsearch container properties with Spring's DynamicPropertyRegistry.
+	 * <p>
+	 * Registers the following properties:
+	 * <ul>
+	 *   <li>spring.jpa.properties.hibernate.search.backend.hosts</li>
+	 *   <li>spring.jpa.properties.hibernate.search.backend.protocol</li>
+	 *   <li>spring.jpa.properties.hibernate.search.backend.username</li>
+	 *   <li>spring.jpa.properties.hibernate.search.backend.password</li>
+	 * </ul>
+	 *
+	 * @param registry  the Spring dynamic property registry
+	 * @param container the Elasticsearch container
+	 */
+	public static void registerElasticsearchProperties(DynamicPropertyRegistry registry, ElasticsearchContainer container) {
+		registry.add("spring.jpa.properties.hibernate.search.backend.hosts", container::getHttpHostAddress);
+		registry.add("spring.jpa.properties.hibernate.search.backend.protocol", () -> "http");
+		registry.add("spring.jpa.properties.hibernate.search.backend.username", () -> "");
+		registry.add("spring.jpa.properties.hibernate.search.backend.password", () -> "");
+	}
+
+	/**
+	 * Registers both PostgreSQL and Elasticsearch container properties with Spring's DynamicPropertyRegistry.
+	 *
+	 * @param registry      the Spring dynamic property registry
+	 * @param postgres      the PostgreSQL container
+	 * @param elasticsearch the Elasticsearch container
+	 */
+	public static void registerPostgresAndElasticsearchProperties(
+		DynamicPropertyRegistry registry,
+		PostgreSQLContainer<?> postgres,
+		ElasticsearchContainer elasticsearch
+	) {
+		registerPostgresProperties(registry, postgres);
+		registerElasticsearchProperties(registry, elasticsearch);
+	}
+
+	/**
+	 * Returns the Elasticsearch HTTP URL for a container.
+	 * <p>
+	 * Example: "http://localhost:49152"
+	 *
+	 * @param container the Elasticsearch container
+	 * @return the full HTTP URL to the Elasticsearch instance
+	 */
+	public static String getElasticsearchHttpUrl(ElasticsearchContainer container) {
+		return "http://" + container.getHost() + ":" + container.getMappedPort(9200);
+	}
+
+}

--- a/src/test/resources/test-elasticsearch-lastn.yaml
+++ b/src/test/resources/test-elasticsearch-lastn.yaml
@@ -2,6 +2,7 @@ hapi:
   fhir:
     fhir_version: r4
     cr_enabled: false
+    lastn_enabled: true
     advanced_lucene_indexing: true
     store_resource_in_lucene_index_enabled: true
     search_index_full_text_enabled: true
@@ -9,17 +10,15 @@ hapi:
 spring:
   main:
     allow-bean-definition-overriding: true
-  # PostgreSQL datasource properties - set dynamically by TestContainerHelper.registerPostgresProperties()
+  # H2 in-memory datasource for this test
   datasource:
-    url: # Set dynamically from PostgreSQLContainer
-    username: # Set dynamically from PostgreSQLContainer
-    password: # Set dynamically from PostgreSQLContainer
-    driver-class-name: # Set dynamically from PostgreSQLContainer
+    url: jdbc:h2:mem:dbr4
+  # Elasticsearch URI - set dynamically for ElasticConfigCondition to enable ElasticsearchBootSvcImpl
+  elasticsearch:
+    uris: # Set dynamically from ElasticsearchContainer via TestContainerHelper.getElasticsearchHttpUrl()
   jpa:
     properties:
       hibernate:
-        # PostgreSQL dialect - set dynamically by TestContainerHelper.registerPostgresProperties()
-        dialect: # Set dynamically to ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect
         search:
           enabled: true
           backend:

--- a/src/test/resources/test-postgres-lucene.yaml
+++ b/src/test/resources/test-postgres-lucene.yaml
@@ -9,9 +9,17 @@ hapi:
 spring:
   main:
     allow-bean-definition-overriding: true
+  # PostgreSQL datasource properties - set dynamically by TestContainerHelper.registerPostgresProperties()
+  datasource:
+    url: # Set dynamically from PostgreSQLContainer
+    username: # Set dynamically from PostgreSQLContainer
+    password: # Set dynamically from PostgreSQLContainer
+    driver-class-name: # Set dynamically from PostgreSQLContainer
   jpa:
     properties:
       hibernate:
+        # PostgreSQL dialect - set dynamically by TestContainerHelper.registerPostgresProperties()
+        dialect: # Set dynamically to ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect
         search:
           enabled: true
           backend:


### PR DESCRIPTION
## Summary

This PR introduces a `TestContainerHelper` utility class to simplify and standardize the configuration of Testcontainers in integration tests. The changes reduce code duplication and make it easier to write new integration tests.

### Changes

- **New `TestContainerHelper` class** (`src/test/java/ca/uhn/fhir/jpa/starter/common/TestContainerHelper.java`)
  - Factory methods for creating pre-configured PostgreSQL and Elasticsearch containers
  - Utility methods for registering container properties with Spring's `DynamicPropertyRegistry`
  - Centralized container image versions and default configurations
  - Comprehensive Javadoc with usage examples

- **Refactored integration tests** to use the new helper:
  - `ElasticsearchLastNR4IT` - Simplified from ~180 lines to ~100 lines
  - `PostgresElasticsearchPatientIT` - Removed duplicate container configuration
  - `PostgresLucenePatientIT` - Removed duplicate container configuration

- **New/updated test configuration files**:
  - `test-elasticsearch-lastn.yaml` - Dedicated config for LastN Elasticsearch tests
  - `test-postgres-elasticsearch.yaml` - Updated with documented dynamic properties
  - `test-postgres-lucene.yaml` - Updated with documented dynamic properties

### Benefits

- **Reduced duplication**: Container creation and property registration code is now centralized
- **Easier maintenance**: Container versions and configurations are defined in one place
- **Better documentation**: YAML files now document which properties are set dynamically
- **Simplified test writing**: New tests can use simple one-liners to create containers

### Example Usage
```java
@Testcontainers
@SpringBootTest
class MyIntegrationTest {

    @Container
    private static final PostgreSQLContainer<?> POSTGRES = TestContainerHelper.newPostgresContainer();

    @Container
    private static final ElasticsearchContainer ELASTICSEARCH = TestContainerHelper.newElasticsearchContainer();

    @DynamicPropertySource
    static void registerProperties(DynamicPropertyRegistry registry) {
        TestContainerHelper.registerPostgresAndElasticsearchProperties(registry, POSTGRES, ELASTICSEARCH);
    }
}
```

## Test plan

- [x] All existing integration tests pass
- [x] `ElasticsearchLastNR4IT` - Verified LastN functionality works
- [x] `PostgresElasticsearchPatientIT` - Verified PostgreSQL + Elasticsearch search works
- [x] `PostgresLucenePatientIT` - Verified PostgreSQL + Lucene search works
