### PR TITLE
Add fallback for versioned base FHIR StructureDefinition lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ Temporary Items
 
 # Helm Chart dependencies
 **/charts/*.tgz
+.claude

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackConfig.java
@@ -21,11 +21,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class VersionedUrlFallbackConfig {
 
-    private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackConfig.class);
+	private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackConfig.class);
 
-    public VersionedUrlFallbackConfig(FhirContext theFhirContext, ValidationSupportChain theValidationSupportChain) {
-        ourLog.info("Adding VersionedUrlFallbackValidationSupport to validation chain");
-        theValidationSupportChain.addValidationSupport(0,
-                new VersionedUrlFallbackValidationSupport(theFhirContext, theValidationSupportChain));
-    }
+	public VersionedUrlFallbackConfig(FhirContext theFhirContext, ValidationSupportChain theValidationSupportChain) {
+		ourLog.info("Adding VersionedUrlFallbackValidationSupport to validation chain");
+		theValidationSupportChain.addValidationSupport(
+				0, new VersionedUrlFallbackValidationSupport(theFhirContext, theValidationSupportChain));
+	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackConfig.java
@@ -11,9 +11,7 @@ import org.springframework.context.annotation.Configuration;
  *
  * This wraps the validation support chain to add fallback logic for versioned canonical URLs.
  * When a versioned URL like "http://hl7.org/fhir/StructureDefinition/Organization|4.0.1"
- * cannot be found, it will automatically fall back to:
- * 1. Major.minor version (e.g., |4.0)
- * 2. Non-versioned URL (without the |version suffix)
+ * cannot be found, it will automatically fall back to Non-versioned URL (without the |version suffix)
  *
  * This is useful when Implementation Guides reference versioned base FHIR resources
  * that aren't loaded with exact version matching.

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackConfig.java
@@ -1,0 +1,31 @@
+package ca.uhn.fhir.jpa.starter.validation;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration that enables versioned URL fallback behavior for FHIR validation.
+ *
+ * This wraps the validation support chain to add fallback logic for versioned canonical URLs.
+ * When a versioned URL like "http://hl7.org/fhir/StructureDefinition/Organization|4.0.1"
+ * cannot be found, it will automatically fall back to:
+ * 1. Major.minor version (e.g., |4.0)
+ * 2. Non-versioned URL (without the |version suffix)
+ *
+ * This is useful when Implementation Guides reference versioned base FHIR resources
+ * that aren't loaded with exact version matching.
+ */
+@Configuration
+public class VersionedUrlFallbackConfig {
+
+    private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackConfig.class);
+
+    public VersionedUrlFallbackConfig(FhirContext theFhirContext, ValidationSupportChain theValidationSupportChain) {
+        ourLog.info("Adding VersionedUrlFallbackValidationSupport to validation chain");
+        theValidationSupportChain.addValidationSupport(0,
+                new VersionedUrlFallbackValidationSupport(theFhirContext, theValidationSupportChain));
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
@@ -1,0 +1,203 @@
+package ca.uhn.fhir.jpa.starter.validation;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.IValidationSupport;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * A validation support that provides fallback behavior for versioned canonical URLs.
+ *
+ * When a versioned URL like "http://hl7.org/fhir/StructureDefinition/Organization|4.0.1"
+ * is requested, this support will:
+ * 1. Return null for the exact versioned lookup (letting other supports try)
+ * 2. When the chain reaches this point and nothing has been found, it tries fallback lookups
+ *
+ * The fallback logic attempts:
+ * 1. Major.minor version fallback (e.g., 4.0.1 -> 4.0)
+ * 2. Non-versioned URL fallback
+ *
+ * This addresses issues where profiles reference versioned base FHIR resources that
+ * aren't available with exact version matching in the validation context.
+ */
+public class VersionedUrlFallbackValidationSupport implements IValidationSupport {
+
+    private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackValidationSupport.class);
+
+    public static final String DEFAULT_URL_PREFIX = "http://hl7.org/fhir/StructureDefinition/";
+
+    private final FhirContext myFhirContext;
+    private final IValidationSupport myChain;
+    private final Set<String> myUrlPrefixes;
+    // Track if we're in a fallback lookup to prevent recursion
+    private final ThreadLocal<Boolean> myInFallback = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    /**
+     * Creates a fallback validation support that only applies to URLs starting with the default prefix
+     * (http://hl7.org/fhir/StructureDefinition/).
+     */
+    public VersionedUrlFallbackValidationSupport(FhirContext theFhirContext, IValidationSupport theChain) {
+        this(theFhirContext, theChain, Set.of(DEFAULT_URL_PREFIX));
+    }
+
+    /**
+     * Creates a fallback validation support that only applies to URLs starting with the specified prefixes.
+     *
+     * @param theFhirContext the FHIR context
+     * @param theChain the validation support chain to delegate fallback lookups to
+     * @param theUrlPrefixes the URL prefixes to apply fallback logic to (e.g., "http://hl7.org/fhir/StructureDefinition/").
+     *                       Pass an empty set to apply to all URLs.
+     */
+    public VersionedUrlFallbackValidationSupport(FhirContext theFhirContext, IValidationSupport theChain, Set<String> theUrlPrefixes) {
+        myFhirContext = theFhirContext;
+        myChain = theChain;
+        myUrlPrefixes = theUrlPrefixes;
+    }
+
+    @Override
+    public FhirContext getFhirContext() {
+        return myFhirContext;
+    }
+
+    @Override
+    public <T extends IBaseResource> T fetchResource(Class<T> theClass, String theUri) {
+        // If we're already in a fallback lookup, don't do anything to avoid recursion
+        if (Boolean.TRUE.equals(myInFallback.get())) {
+            return null;
+        }
+
+        // Check if this is a versioned URL (contains |)
+        int pipeIndex = theUri.indexOf('|');
+        if (pipeIndex <= 0) {
+            // Not a versioned URL, let other supports handle it
+            return null;
+        }
+
+        String baseUrl = theUri.substring(0, pipeIndex);
+
+        // Check if this URL matches our configured prefixes
+        if (!matchesPrefix(baseUrl)) {
+            return null;
+        }
+
+        String version = theUri.substring(pipeIndex + 1);
+
+        try {
+            myInFallback.set(Boolean.TRUE);
+
+            // Try major.minor version fallback (e.g., 4.0.1 -> 4.0)
+            String majorMinorVersion = extractMajorMinorVersion(version);
+            if (majorMinorVersion != null && !majorMinorVersion.equals(version)) {
+                String majorMinorUri = baseUrl + "|" + majorMinorVersion;
+                T result = myChain.fetchResource(theClass, majorMinorUri);
+                if (result != null) {
+                    ourLog.warn("Requested versioned canonical '{}' not found, falling back to major.minor version '{}'",
+                            theUri, majorMinorUri);
+                    return result;
+                }
+            }
+
+            // Try non-versioned URL fallback
+            T result = myChain.fetchResource(theClass, baseUrl);
+            if (result != null) {
+                ourLog.warn("Requested versioned canonical '{}' not found, falling back to non-versioned '{}'",
+                        theUri, baseUrl);
+                return result;
+            }
+
+        } finally {
+            myInFallback.set(Boolean.FALSE);
+        }
+
+        return null;
+    }
+
+    @Override
+    public IBaseResource fetchStructureDefinition(String theUrl) {
+        // If we're already in a fallback lookup, don't do anything to avoid recursion
+        if (Boolean.TRUE.equals(myInFallback.get())) {
+            return null;
+        }
+
+        // Check if this is a versioned URL
+        int pipeIndex = theUrl.indexOf('|');
+        if (pipeIndex <= 0) {
+            // Not a versioned URL, let other supports handle it
+            return null;
+        }
+
+        String baseUrl = theUrl.substring(0, pipeIndex);
+
+        // Check if this URL matches our configured prefixes
+        if (!matchesPrefix(baseUrl)) {
+            return null;
+        }
+
+        String version = theUrl.substring(pipeIndex + 1);
+
+        try {
+            myInFallback.set(Boolean.TRUE);
+
+            // Try major.minor version fallback
+            String majorMinorVersion = extractMajorMinorVersion(version);
+            if (majorMinorVersion != null && !majorMinorVersion.equals(version)) {
+                String majorMinorUri = baseUrl + "|" + majorMinorVersion;
+                IBaseResource result = myChain.fetchStructureDefinition(majorMinorUri);
+                if (result != null) {
+                    ourLog.warn("Requested versioned StructureDefinition '{}' not found, falling back to major.minor version '{}'",
+                            theUrl, majorMinorUri);
+                    return result;
+                }
+            }
+
+            // Try non-versioned URL fallback
+            IBaseResource result = myChain.fetchStructureDefinition(baseUrl);
+            if (result != null) {
+                ourLog.warn("Requested versioned StructureDefinition '{}' not found, falling back to non-versioned '{}'",
+                        theUrl, baseUrl);
+                return result;
+            }
+
+        } finally {
+            myInFallback.set(Boolean.FALSE);
+        }
+
+        return null;
+    }
+
+    private boolean matchesPrefix(String theUrl) {
+        if (myUrlPrefixes.isEmpty()) {
+            return true;
+        }
+        for (String prefix : myUrlPrefixes) {
+            if (theUrl.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Extracts major.minor version from a full version string.
+     * For example: "4.0.1" -> "4.0", "4.0" -> "4.0", "4" -> null
+     */
+    private String extractMajorMinorVersion(String version) {
+        if (version == null || version.isEmpty()) {
+            return null;
+        }
+
+        String[] parts = version.split("\\.");
+        if (parts.length >= 2) {
+            return parts[0] + "." + parts[1];
+        }
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return "VersionedUrlFallbackValidationSupport";
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
@@ -26,8 +26,6 @@ public class VersionedUrlFallbackValidationSupport implements IValidationSupport
 
 	private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackValidationSupport.class);
 
-	public static final String DEFAULT_URL_PREFIX = "http://hl7.org/fhir/StructureDefinition/";
-
 	private final FhirContext myFhirContext;
 	private final IValidationSupport myChain;
 	private final Set<String> myUrlPrefixes;
@@ -37,7 +35,7 @@ public class VersionedUrlFallbackValidationSupport implements IValidationSupport
 	 * (http://hl7.org/fhir/StructureDefinition/).
 	 */
 	public VersionedUrlFallbackValidationSupport(FhirContext theFhirContext, IValidationSupport theChain) {
-		this(theFhirContext, theChain, Set.of(DEFAULT_URL_PREFIX));
+		this(theFhirContext, theChain, Set.of(URL_PREFIX_STRUCTURE_DEFINITION));
 	}
 
 	/**

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
@@ -26,135 +26,140 @@ import java.util.function.Function;
  */
 public class VersionedUrlFallbackValidationSupport implements IValidationSupport {
 
-    private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackValidationSupport.class);
+	private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackValidationSupport.class);
 
-    public static final String DEFAULT_URL_PREFIX = "http://hl7.org/fhir/StructureDefinition/";
+	public static final String DEFAULT_URL_PREFIX = "http://hl7.org/fhir/StructureDefinition/";
 
-    private final FhirContext myFhirContext;
-    private final IValidationSupport myChain;
-    private final Set<String> myUrlPrefixes;
-    // Track if we're in a fallback lookup to prevent recursion
-    private final ThreadLocal<Boolean> myInFallback = ThreadLocal.withInitial(() -> Boolean.FALSE);
+	private final FhirContext myFhirContext;
+	private final IValidationSupport myChain;
+	private final Set<String> myUrlPrefixes;
+	// Track if we're in a fallback lookup to prevent recursion
+	private final ThreadLocal<Boolean> myInFallback = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
-    /**
-     * Creates a fallback validation support that only applies to URLs starting with the default prefix
-     * (http://hl7.org/fhir/StructureDefinition/).
-     */
-    public VersionedUrlFallbackValidationSupport(FhirContext theFhirContext, IValidationSupport theChain) {
-        this(theFhirContext, theChain, Set.of(DEFAULT_URL_PREFIX));
-    }
+	/**
+	 * Creates a fallback validation support that only applies to URLs starting with the default prefix
+	 * (http://hl7.org/fhir/StructureDefinition/).
+	 */
+	public VersionedUrlFallbackValidationSupport(FhirContext theFhirContext, IValidationSupport theChain) {
+		this(theFhirContext, theChain, Set.of(DEFAULT_URL_PREFIX));
+	}
 
-    /**
-     * Creates a fallback validation support that only applies to URLs starting with the specified prefixes.
-     *
-     * @param theFhirContext the FHIR context
-     * @param theChain the validation support chain to delegate fallback lookups to
-     * @param theUrlPrefixes the URL prefixes to apply fallback logic to (e.g., "http://hl7.org/fhir/StructureDefinition/").
-     *                       Pass an empty set to apply to all URLs.
-     */
-    public VersionedUrlFallbackValidationSupport(FhirContext theFhirContext, IValidationSupport theChain, Set<String> theUrlPrefixes) {
-        myFhirContext = theFhirContext;
-        myChain = theChain;
-        myUrlPrefixes = theUrlPrefixes;
-    }
+	/**
+	 * Creates a fallback validation support that only applies to URLs starting with the specified prefixes.
+	 *
+	 * @param theFhirContext the FHIR context
+	 * @param theChain the validation support chain to delegate fallback lookups to
+	 * @param theUrlPrefixes the URL prefixes to apply fallback logic to (e.g., "http://hl7.org/fhir/StructureDefinition/").
+	 *                       Pass an empty set to apply to all URLs.
+	 */
+	public VersionedUrlFallbackValidationSupport(
+			FhirContext theFhirContext, IValidationSupport theChain, Set<String> theUrlPrefixes) {
+		myFhirContext = theFhirContext;
+		myChain = theChain;
+		myUrlPrefixes = theUrlPrefixes;
+	}
 
-    @Override
-    public FhirContext getFhirContext() {
-        return myFhirContext;
-    }
+	@Override
+	public FhirContext getFhirContext() {
+		return myFhirContext;
+	}
 
-    @Override
-    public <T extends IBaseResource> T fetchResource(Class<T> theClass, String theUri) {
-        return doFetchWithFallback(theUri, uri -> myChain.fetchResource(theClass, uri));
-    }
+	@Override
+	public <T extends IBaseResource> T fetchResource(Class<T> theClass, String theUri) {
+		return doFetchWithFallback(theUri, uri -> myChain.fetchResource(theClass, uri));
+	}
 
-    @Override
-    public IBaseResource fetchStructureDefinition(String theUrl) {
-        return doFetchWithFallback(theUrl, myChain::fetchStructureDefinition);
-    }
+	@Override
+	public IBaseResource fetchStructureDefinition(String theUrl) {
+		return doFetchWithFallback(theUrl, myChain::fetchStructureDefinition);
+	}
 
-    private <T extends IBaseResource> T doFetchWithFallback(String theUrl, Function<String, T> theFetcher) {
-        // If we're already in a fallback lookup, don't do anything to avoid recursion
-        if (Boolean.TRUE.equals(myInFallback.get())) {
-            return null;
-        }
+	private <T extends IBaseResource> T doFetchWithFallback(String theUrl, Function<String, T> theFetcher) {
+		// If we're already in a fallback lookup, don't do anything to avoid recursion
+		if (Boolean.TRUE.equals(myInFallback.get())) {
+			return null;
+		}
 
-        // Check if this is a versioned URL (contains |)
-        int pipeIndex = theUrl.indexOf('|');
-        if (pipeIndex <= 0) {
-            // Not a versioned URL, let other supports handle it
-            return null;
-        }
+		// Check if this is a versioned URL (contains |)
+		int pipeIndex = theUrl.indexOf('|');
+		if (pipeIndex <= 0) {
+			// Not a versioned URL, let other supports handle it
+			return null;
+		}
 
-        String baseUrl = theUrl.substring(0, pipeIndex);
+		String baseUrl = theUrl.substring(0, pipeIndex);
 
-        // Check if this URL matches our configured prefixes
-        if (!matchesPrefix(baseUrl)) {
-            return null;
-        }
+		// Check if this URL matches our configured prefixes
+		if (!matchesPrefix(baseUrl)) {
+			return null;
+		}
 
-        String version = theUrl.substring(pipeIndex + 1);
+		String version = theUrl.substring(pipeIndex + 1);
 
-        try {
-            myInFallback.set(Boolean.TRUE);
+		try {
+			myInFallback.set(Boolean.TRUE);
 
-            // Try major.minor version fallback (e.g., 4.0.1 -> 4.0)
-            String majorMinorVersion = extractMajorMinorVersion(version);
-            if (majorMinorVersion != null && !majorMinorVersion.equals(version)) {
-                String majorMinorUrl = baseUrl + "|" + majorMinorVersion;
-                T result = theFetcher.apply(majorMinorUrl);
-                if (result != null) {
-                    ourLog.warn("Requested versioned canonical '{}' not found, falling back to major.minor version '{}'",
-                            theUrl, majorMinorUrl);
-                    return result;
-                }
-            }
+			// Try major.minor version fallback (e.g., 4.0.1 -> 4.0)
+			String majorMinorVersion = extractMajorMinorVersion(version);
+			if (majorMinorVersion != null && !majorMinorVersion.equals(version)) {
+				String majorMinorUrl = baseUrl + "|" + majorMinorVersion;
+				T result = theFetcher.apply(majorMinorUrl);
+				if (result != null) {
+					ourLog.warn(
+							"Requested versioned canonical '{}' not found, falling back to major.minor version '{}'",
+							theUrl,
+							majorMinorUrl);
+					return result;
+				}
+			}
 
-            // Try non-versioned URL fallback
-            T result = theFetcher.apply(baseUrl);
-            if (result != null) {
-                ourLog.warn("Requested versioned canonical '{}' not found, falling back to non-versioned '{}'",
-                        theUrl, baseUrl);
-                return result;
-            }
+			// Try non-versioned URL fallback
+			T result = theFetcher.apply(baseUrl);
+			if (result != null) {
+				ourLog.warn(
+						"Requested versioned canonical '{}' not found, falling back to non-versioned '{}'",
+						theUrl,
+						baseUrl);
+				return result;
+			}
 
-        } finally {
-            myInFallback.set(Boolean.FALSE);
-        }
+		} finally {
+			myInFallback.set(Boolean.FALSE);
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    private boolean matchesPrefix(String theUrl) {
-        if (myUrlPrefixes.isEmpty()) {
-            return true;
-        }
-        for (String prefix : myUrlPrefixes) {
-            if (theUrl.startsWith(prefix)) {
-                return true;
-            }
-        }
-        return false;
-    }
+	private boolean matchesPrefix(String theUrl) {
+		if (myUrlPrefixes.isEmpty()) {
+			return true;
+		}
+		for (String prefix : myUrlPrefixes) {
+			if (theUrl.startsWith(prefix)) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-    /**
-     * Extracts major.minor version from a full version string.
-     * For example: "4.0.1" -> "4.0", "4.0" -> "4.0", "4" -> null
-     */
-    private String extractMajorMinorVersion(String version) {
-        if (version == null || version.isEmpty()) {
-            return null;
-        }
+	/**
+	 * Extracts major.minor version from a full version string.
+	 * For example: "4.0.1" -> "4.0", "4.0" -> "4.0", "4" -> null
+	 */
+	private String extractMajorMinorVersion(String version) {
+		if (version == null || version.isEmpty()) {
+			return null;
+		}
 
-        String[] parts = version.split("\\.");
-        if (parts.length >= 2) {
-            return parts[0] + "." + parts[1];
-        }
-        return null;
-    }
+		String[] parts = version.split("\\.");
+		if (parts.length >= 2) {
+			return parts[0] + "." + parts[1];
+		}
+		return null;
+	}
 
-    @Override
-    public String getName() {
-        return "VersionedUrlFallbackValidationSupport";
-    }
+	@Override
+	public String getName() {
+		return "VersionedUrlFallbackValidationSupport";
+	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
  * This addresses issues where profiles reference versioned base FHIR resources that
  * aren't available with exact version matching in the validation context.
  */
+//TODO: this should be fixed in core
 public class VersionedUrlFallbackValidationSupport implements IValidationSupport {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackValidationSupport.class);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  * This addresses issues where profiles reference versioned base FHIR resources that
  * aren't available with exact version matching in the validation context.
  */
-//TODO: this should be fixed in core
+// TODO: this should be fixed in core
 public class VersionedUrlFallbackValidationSupport implements IValidationSupport {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(VersionedUrlFallbackValidationSupport.class);

--- a/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
@@ -203,7 +203,7 @@ class VersionedUrlFallbackValidationSupportTest {
     @Test
     void testDefaultUrlPrefix() {
         assertEquals("http://hl7.org/fhir/StructureDefinition/",
-			  URL_PREFIX_STRUCTURE_DEFINITION);
+                URL_PREFIX_STRUCTURE_DEFINITION);
     }
 
     /**

--- a/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
@@ -1,9 +1,12 @@
 package ca.uhn.fhir.jpa.starter.validation;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
 import ca.uhn.fhir.context.support.IValidationSupport;
+import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
 import org.hl7.fhir.r4.model.StructureDefinition;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -11,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
 
+import static ca.uhn.fhir.context.support.IValidationSupport.URL_PREFIX_STRUCTURE_DEFINITION;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -199,6 +203,102 @@ class VersionedUrlFallbackValidationSupportTest {
     @Test
     void testDefaultUrlPrefix() {
         assertEquals("http://hl7.org/fhir/StructureDefinition/",
-                VersionedUrlFallbackValidationSupport.DEFAULT_URL_PREFIX);
+			  URL_PREFIX_STRUCTURE_DEFINITION);
+    }
+
+    /**
+     * Integration tests using real DefaultProfileValidationSupport instead of mocks.
+     * This tests the actual fallback behavior with FHIR's built-in profiles.
+     */
+    @Nested
+    class WithRealValidationChain {
+
+        private FhirContext myFhirContext;
+        private ValidationSupportChain myValidationChain;
+        private VersionedUrlFallbackValidationSupport mySvc;
+
+        @BeforeEach
+        void setUp() {
+            myFhirContext = FhirContext.forR4Cached();
+
+            // Create a validation chain with the real DefaultProfileValidationSupport
+            // which contains all built-in FHIR R4 StructureDefinitions
+            myValidationChain = new ValidationSupportChain(new DefaultProfileValidationSupport(myFhirContext));
+
+            // Wrap the chain with our fallback support, similar to production setup
+            mySvc = new VersionedUrlFallbackValidationSupport(myFhirContext, myValidationChain);
+        }
+
+        @Test
+        void testFallbackToNonVersionedUrl_WithRealDefaultProfile() {
+            // The DefaultProfileValidationSupport has Organization without version suffix.
+            // When we request versioned URL, it should fall back and find it.
+            String versionedUrl = "http://hl7.org/fhir/StructureDefinition/Organization|4.0.1";
+
+            var result = mySvc.fetchStructureDefinition(versionedUrl);
+
+            assertNotNull(result, "Should find Organization via fallback to non-versioned URL");
+            assertInstanceOf(StructureDefinition.class, result);
+            StructureDefinition sd = (StructureDefinition) result;
+            assertEquals("http://hl7.org/fhir/StructureDefinition/Organization", sd.getUrl());
+            assertEquals("Organization", sd.getName());
+        }
+
+        @Test
+        void testFallbackForPatient_WithRealDefaultProfile() {
+            String versionedUrl = "http://hl7.org/fhir/StructureDefinition/Patient|4.0.1";
+
+            var result = mySvc.fetchStructureDefinition(versionedUrl);
+
+            assertNotNull(result, "Should find Patient via fallback");
+            assertInstanceOf(StructureDefinition.class, result);
+            StructureDefinition sd = (StructureDefinition) result;
+            assertEquals("http://hl7.org/fhir/StructureDefinition/Patient", sd.getUrl());
+        }
+
+        @Test
+        void testFetchResource_WithRealDefaultProfile() {
+            String versionedUrl = "http://hl7.org/fhir/StructureDefinition/Observation|4.0.1";
+
+            var result = mySvc.fetchResource(StructureDefinition.class, versionedUrl);
+
+            assertNotNull(result, "Should find Observation via fetchResource fallback");
+            assertEquals("http://hl7.org/fhir/StructureDefinition/Observation", result.getUrl());
+        }
+
+        @Test
+        void testNonExistentResource_ReturnsNull() {
+            String versionedUrl = "http://hl7.org/fhir/StructureDefinition/NonExistentResource|1.0.0";
+
+            var result = mySvc.fetchStructureDefinition(versionedUrl);
+
+            assertNull(result, "Should return null for non-existent resource");
+        }
+
+        @Test
+        void testNonVersionedUrl_PassesThrough() {
+            // Non-versioned URLs should return null from the fallback support
+            // (they're handled by DefaultProfileValidationSupport directly in a real chain)
+            String nonVersionedUrl = "http://hl7.org/fhir/StructureDefinition/Patient";
+
+            var result = mySvc.fetchStructureDefinition(nonVersionedUrl);
+
+            // The fallback support returns null for non-versioned URLs
+            // In a real setup, the chain would handle this
+            assertNull(result);
+        }
+
+        @Test
+        void testDataTypeProfiles_WithRealDefaultProfile() {
+            // Test that data type StructureDefinitions also work
+            String versionedUrl = "http://hl7.org/fhir/StructureDefinition/HumanName|4.0.1";
+
+            var result = mySvc.fetchStructureDefinition(versionedUrl);
+
+            assertNotNull(result, "Should find HumanName data type via fallback");
+            assertInstanceOf(StructureDefinition.class, result);
+            assertEquals("http://hl7.org/fhir/StructureDefinition/HumanName",
+                    ((StructureDefinition) result).getUrl());
+        }
     }
 }

--- a/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
@@ -1,0 +1,238 @@
+package ca.uhn.fhir.jpa.starter.validation;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.IValidationSupport;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VersionedUrlFallbackValidationSupportTest {
+
+    private static final String BASE_FHIR_SD_PREFIX = "http://hl7.org/fhir/StructureDefinition/";
+    private static final String ORGANIZATION_URL = BASE_FHIR_SD_PREFIX + "Organization";
+    private static final String ORGANIZATION_URL_VERSIONED = ORGANIZATION_URL + "|4.0.1";
+    private static final String ORGANIZATION_URL_MAJOR_MINOR = ORGANIZATION_URL + "|4.0";
+
+    private static final String CUSTOM_SD_URL = "http://example.com/StructureDefinition/MyProfile";
+    private static final String CUSTOM_SD_URL_VERSIONED = CUSTOM_SD_URL + "|1.0.0";
+
+    private FhirContext myFhirContext;
+
+    @Mock
+    private IValidationSupport myChain;
+
+    private VersionedUrlFallbackValidationSupport mySvc;
+
+    @BeforeEach
+    void setUp() {
+        myFhirContext = FhirContext.forR4Cached();
+        mySvc = new VersionedUrlFallbackValidationSupport(myFhirContext, myChain);
+    }
+
+    @Test
+    void testFallbackToNonVersionedUrl_WhenMajorMinorNotFound() {
+        // Setup: major.minor returns null, non-versioned returns a resource
+        StructureDefinition sd = new StructureDefinition();
+        sd.setUrl(ORGANIZATION_URL);
+
+        when(myChain.fetchStructureDefinition(ORGANIZATION_URL_MAJOR_MINOR)).thenReturn(null);
+        when(myChain.fetchStructureDefinition(ORGANIZATION_URL)).thenReturn(sd);
+
+        // Execute
+        var result = mySvc.fetchStructureDefinition(ORGANIZATION_URL_VERSIONED);
+
+        // Verify: fallback to non-versioned succeeds
+        assertNotNull(result);
+        assertSame(sd, result);
+        verify(myChain).fetchStructureDefinition(ORGANIZATION_URL_MAJOR_MINOR);
+        verify(myChain).fetchStructureDefinition(ORGANIZATION_URL);
+    }
+
+    @Test
+    void testFallbackToMajorMinorVersion_WhenAvailable() {
+        // Setup: major.minor version exists
+        StructureDefinition sd = new StructureDefinition();
+        sd.setUrl(ORGANIZATION_URL);
+        sd.setVersion("4.0");
+
+        when(myChain.fetchStructureDefinition(ORGANIZATION_URL_MAJOR_MINOR)).thenReturn(sd);
+
+        // Execute
+        var result = mySvc.fetchStructureDefinition(ORGANIZATION_URL_VERSIONED);
+
+        // Verify: returns major.minor match, doesn't try non-versioned
+        assertNotNull(result);
+        assertSame(sd, result);
+        verify(myChain).fetchStructureDefinition(ORGANIZATION_URL_MAJOR_MINOR);
+        verify(myChain, never()).fetchStructureDefinition(ORGANIZATION_URL);
+    }
+
+    @Test
+    void testNoFallback_ForNonVersionedUrl() {
+        // Execute: non-versioned URL should pass through without any chain calls
+        var result = mySvc.fetchStructureDefinition(ORGANIZATION_URL);
+
+        // Verify: returns null immediately, lets other chain supports handle it
+        assertNull(result);
+        verifyNoInteractions(myChain);
+    }
+
+    @Test
+    void testNoFallback_ForCustomUrlNotMatchingDefaultPrefix() {
+        // Execute: custom URL doesn't match the default prefix filter
+        var result = mySvc.fetchStructureDefinition(CUSTOM_SD_URL_VERSIONED);
+
+        // Verify: returns null, doesn't attempt fallback (not in prefix list)
+        assertNull(result);
+        verifyNoInteractions(myChain);
+    }
+
+    @Test
+    void testFallback_ForCustomUrl_WhenPrefixConfigured() {
+        // Setup: configure to also handle custom URLs
+        mySvc = new VersionedUrlFallbackValidationSupport(myFhirContext, myChain,
+                Set.of(BASE_FHIR_SD_PREFIX, "http://example.com/StructureDefinition/"));
+
+        StructureDefinition sd = new StructureDefinition();
+        sd.setUrl(CUSTOM_SD_URL);
+
+        when(myChain.fetchStructureDefinition(CUSTOM_SD_URL + "|1.0")).thenReturn(null);
+        when(myChain.fetchStructureDefinition(CUSTOM_SD_URL)).thenReturn(sd);
+
+        // Execute
+        var result = mySvc.fetchStructureDefinition(CUSTOM_SD_URL_VERSIONED);
+
+        // Verify
+        assertNotNull(result);
+        assertSame(sd, result);
+    }
+
+    @Test
+    void testFallback_ForAllUrls_WhenEmptyPrefixSet() {
+        // Setup: empty prefix set means apply to all URLs
+        mySvc = new VersionedUrlFallbackValidationSupport(myFhirContext, myChain, Set.of());
+
+        StructureDefinition sd = new StructureDefinition();
+        sd.setUrl(CUSTOM_SD_URL);
+
+        when(myChain.fetchStructureDefinition(CUSTOM_SD_URL + "|1.0")).thenReturn(null);
+        when(myChain.fetchStructureDefinition(CUSTOM_SD_URL)).thenReturn(sd);
+
+        // Execute
+        var result = mySvc.fetchStructureDefinition(CUSTOM_SD_URL_VERSIONED);
+
+        // Verify
+        assertNotNull(result);
+        assertSame(sd, result);
+    }
+
+    @Test
+    void testFetchResource_FallbackToNonVersioned() {
+        // Setup
+        StructureDefinition sd = new StructureDefinition();
+        sd.setUrl(ORGANIZATION_URL);
+
+        when(myChain.fetchResource(StructureDefinition.class, ORGANIZATION_URL_MAJOR_MINOR)).thenReturn(null);
+        when(myChain.fetchResource(StructureDefinition.class, ORGANIZATION_URL)).thenReturn(sd);
+
+        // Execute
+        var result = mySvc.fetchResource(StructureDefinition.class, ORGANIZATION_URL_VERSIONED);
+
+        // Verify
+        assertNotNull(result);
+        assertSame(sd, result);
+    }
+
+    @Test
+    void testFetchResource_NoFallbackForNonMatchingPrefix() {
+        // Execute
+        var result = mySvc.fetchResource(StructureDefinition.class, CUSTOM_SD_URL_VERSIONED);
+
+        // Verify
+        assertNull(result);
+        verifyNoInteractions(myChain);
+    }
+
+    @Test
+    void testFetchResource_NoFallbackForNonVersionedUrl() {
+        // Execute
+        var result = mySvc.fetchResource(StructureDefinition.class, ORGANIZATION_URL);
+
+        // Verify
+        assertNull(result);
+        verifyNoInteractions(myChain);
+    }
+
+    @Test
+    void testNoMajorMinorFallback_WhenOnlyMajorVersion() {
+        // Setup: version is just "4" (no minor), so no major.minor fallback possible
+        String urlWithMajorOnly = ORGANIZATION_URL + "|4";
+
+        // Only non-versioned lookup should happen (no major.minor to extract)
+        when(myChain.fetchStructureDefinition(ORGANIZATION_URL)).thenReturn(null);
+
+        // Execute
+        var result = mySvc.fetchStructureDefinition(urlWithMajorOnly);
+
+        // Verify: should try non-versioned only (no major.minor since version has no minor part)
+        assertNull(result);
+        verify(myChain).fetchStructureDefinition(ORGANIZATION_URL);
+        verifyNoMoreInteractions(myChain);
+    }
+
+    @Test
+    void testReturnsNull_WhenNoFallbackSucceeds() {
+        // Setup: nothing found in any fallback
+        when(myChain.fetchStructureDefinition(ORGANIZATION_URL_MAJOR_MINOR)).thenReturn(null);
+        when(myChain.fetchStructureDefinition(ORGANIZATION_URL)).thenReturn(null);
+
+        // Execute
+        var result = mySvc.fetchStructureDefinition(ORGANIZATION_URL_VERSIONED);
+
+        // Verify
+        assertNull(result);
+        verify(myChain).fetchStructureDefinition(ORGANIZATION_URL_MAJOR_MINOR);
+        verify(myChain).fetchStructureDefinition(ORGANIZATION_URL);
+    }
+
+    @Test
+    void testNoFallback_WhenMajorMinorSameAsVersion() {
+        // Setup: version is "4.0" which equals major.minor, so only non-versioned fallback
+        String urlWithMajorMinorOnly = ORGANIZATION_URL + "|4.0";
+
+        when(myChain.fetchStructureDefinition(ORGANIZATION_URL)).thenReturn(null);
+
+        // Execute
+        var result = mySvc.fetchStructureDefinition(urlWithMajorMinorOnly);
+
+        // Verify: should skip major.minor fallback (same as requested) and try non-versioned
+        assertNull(result);
+        verify(myChain).fetchStructureDefinition(ORGANIZATION_URL);
+        verifyNoMoreInteractions(myChain);
+    }
+
+    @Test
+    void testGetName() {
+        assertEquals("VersionedUrlFallbackValidationSupport", mySvc.getName());
+    }
+
+    @Test
+    void testGetFhirContext() {
+        assertSame(myFhirContext, mySvc.getFhirContext());
+    }
+
+    @Test
+    void testDefaultUrlPrefix() {
+        assertEquals("http://hl7.org/fhir/StructureDefinition/",
+                VersionedUrlFallbackValidationSupport.DEFAULT_URL_PREFIX);
+    }
+}


### PR DESCRIPTION
Problem:
Implementation Guides (e.g., ch-core) may reference base FHIR resources with explicit versions like "http://hl7.org/fhir/StructureDefinition/Organization|4.0.1". These lookups fail because base FHIR StructureDefinitions are intentionally cached without version (see hapi-fhir PR #7236).

This causes validation errors like:
- "Unable to resolve the profile reference '...|4.0.1'"
- "Invalid Resource target type. Found Organization, but expected one of ([])"

Solution:
Add VersionedUrlFallbackValidationSupport that intercepts versioned lookups for base FHIR StructureDefinitions (http://hl7.org/fhir/StructureDefinition/*) and falls back to:
1. Major.minor version (e.g., 4.0.1 -> 4.0)
2. Non-versioned URL

The fallback logs a warning when triggered, allowing visibility into which IGs reference versioned base resources.