### PR TITLE
feat: add support for enabling/disabling ValidationSupportChain cache via configuration

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -962,6 +962,7 @@ public class AppProperties {
 
 		private Boolean requests_enabled = false;
 		private Boolean responses_enabled = false;
+		private Boolean support_chain_cache_enabled = true;
 
 		public Boolean getRequests_enabled() {
 			return requests_enabled;
@@ -977,6 +978,14 @@ public class AppProperties {
 
 		public void setResponses_enabled(Boolean responses_enabled) {
 			this.responses_enabled = responses_enabled;
+		}
+
+		public Boolean getSupport_chain_cache_enabled() {
+			return support_chain_cache_enabled;
+		}
+
+		public void setSupport_chain_cache_enabled(Boolean support_chain_cache_enabled) {
+			this.support_chain_cache_enabled = support_chain_cache_enabled;
 		}
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfig.java
@@ -7,6 +7,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+/**
+ * Disables the ValidationSupportChain cache when configured via
+ * {@code hapi.fhir.validation.support_chain_cache_enabled}.
+ * Use this when remote terminology responses must always be fresh or when
+ * troubleshooting cache-related behavior.
+ */
 public class ValidationSupportChainCacheConfig {
 
 	@Bean

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfig.java
@@ -1,0 +1,27 @@
+package ca.uhn.fhir.jpa.starter.common.validation;
+
+import ca.uhn.fhir.jpa.starter.AppProperties;
+import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ValidationSupportChainCacheConfig {
+
+	@Bean
+	public BeanPostProcessor validationSupportChainCacheConfigurationPostProcessor(AppProperties theAppProperties) {
+		return new BeanPostProcessor() {
+			@Override
+			public Object postProcessAfterInitialization(Object bean, String beanName) {
+				if (!Boolean.TRUE.equals(
+								theAppProperties.getValidation().getSupport_chain_cache_enabled())
+						&& bean instanceof ValidationSupportChain.CacheConfiguration
+						&& "validationSupportChainCacheConfiguration".equals(beanName)) {
+					return ValidationSupportChain.CacheConfiguration.disabled();
+				}
+				return bean;
+			}
+		};
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfig.java
@@ -14,8 +14,7 @@ public class ValidationSupportChainCacheConfig {
 		return new BeanPostProcessor() {
 			@Override
 			public Object postProcessAfterInitialization(Object bean, String beanName) {
-				if (!Boolean.TRUE.equals(
-								theAppProperties.getValidation().getSupport_chain_cache_enabled())
+				if (!Boolean.TRUE.equals(theAppProperties.getValidation().getSupport_chain_cache_enabled())
 						&& bean instanceof ValidationSupportChain.CacheConfiguration
 						&& "validationSupportChainCacheConfiguration".equals(beanName)) {
 					return ValidationSupportChain.CacheConfiguration.disabled();

--- a/src/main/resources/application-cds.yaml
+++ b/src/main/resources/application-cds.yaml
@@ -296,6 +296,7 @@ hapi:
     # validation:
     #   requests_enabled: true
     #   responses_enabled: true
+    #   support_chain_cache_enabled: true
 
     # -------------------------------------------------------------------------------
     # H. MDM (Master Data Management)

--- a/src/main/resources/application-cds.yaml
+++ b/src/main/resources/application-cds.yaml
@@ -296,7 +296,7 @@ hapi:
     # validation:
     #   requests_enabled: true
     #   responses_enabled: true
-    #   support_chain_cache_enabled: true
+    #   support_chain_cache_enabled: false
 
     # -------------------------------------------------------------------------------
     # H. MDM (Master Data Management)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -302,9 +302,10 @@ hapi:
     # G. Narrative & Validation
     # -------------------------------------------------------------------------------
     narrative_enabled: false
-    # validation:
+    validation:
     #   requests_enabled: true
     #   responses_enabled: true
+      support_chain_cache_enabled: false
 
     # -------------------------------------------------------------------------------
     # H. MDM (Master Data Management)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -305,7 +305,7 @@ hapi:
     validation:
     #   requests_enabled: true
     #   responses_enabled: true
-      support_chain_cache_enabled: false
+      support_chain_cache_enabled: true
 
     # -------------------------------------------------------------------------------
     # H. MDM (Master Data Management)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -305,7 +305,7 @@ hapi:
     validation:
     #   requests_enabled: true
     #   responses_enabled: true
-      support_chain_cache_enabled: true
+    #   support_chain_cache_enabled: false
 
     # -------------------------------------------------------------------------------
     # H. MDM (Master Data Management)

--- a/src/test/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfigTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfigTest.java
@@ -46,4 +46,45 @@ class ValidationSupportChainCacheConfigTest {
 
 		assertSame(input, result);
 	}
+
+	@Test
+	void disablesCacheConfigurationWhenPropertyIsNull() {
+		AppProperties properties = new AppProperties();
+		properties.getValidation().setSupport_chain_cache_enabled(null);
+
+		ValidationSupportChainCacheConfig config = new ValidationSupportChainCacheConfig();
+		BeanPostProcessor postProcessor =
+				config.validationSupportChainCacheConfigurationPostProcessor(properties);
+
+		ValidationSupportChain.CacheConfiguration input = ValidationSupportChain.CacheConfiguration.defaultValues();
+		Object result = postProcessor.postProcessAfterInitialization(
+				input, "validationSupportChainCacheConfiguration");
+
+		ValidationSupportChain.CacheConfiguration disabled =
+				ValidationSupportChain.CacheConfiguration.disabled();
+		ValidationSupportChain.CacheConfiguration actual = (ValidationSupportChain.CacheConfiguration) result;
+
+		assertEquals(disabled.getCacheSize(), actual.getCacheSize());
+		assertEquals(disabled.getCacheTimeout(), actual.getCacheTimeout());
+	}
+
+	@Test
+	void leavesDifferentBeanNameOrTypeUnchanged() {
+		AppProperties properties = new AppProperties();
+		properties.getValidation().setSupport_chain_cache_enabled(false);
+
+		ValidationSupportChainCacheConfig config = new ValidationSupportChainCacheConfig();
+		BeanPostProcessor postProcessor =
+				config.validationSupportChainCacheConfigurationPostProcessor(properties);
+
+		ValidationSupportChain.CacheConfiguration input = ValidationSupportChain.CacheConfiguration.defaultValues();
+		Object wrongNameResult = postProcessor.postProcessAfterInitialization(input, "otherBeanName");
+
+		Object differentTypeBean = new Object();
+		Object wrongTypeResult = postProcessor.postProcessAfterInitialization(
+				differentTypeBean, "validationSupportChainCacheConfiguration");
+
+		assertSame(input, wrongNameResult);
+		assertSame(differentTypeBean, wrongTypeResult);
+	}
 }

--- a/src/test/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfigTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/common/validation/ValidationSupportChainCacheConfigTest.java
@@ -1,0 +1,49 @@
+package ca.uhn.fhir.jpa.starter.common.validation;
+
+import ca.uhn.fhir.jpa.starter.AppProperties;
+import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ValidationSupportChainCacheConfigTest {
+
+	@Test
+	void disablesCacheConfigurationWhenPropertyIsFalse() {
+		AppProperties properties = new AppProperties();
+		properties.getValidation().setSupport_chain_cache_enabled(false);
+
+		ValidationSupportChainCacheConfig config = new ValidationSupportChainCacheConfig();
+		BeanPostProcessor postProcessor =
+				config.validationSupportChainCacheConfigurationPostProcessor(properties);
+
+		ValidationSupportChain.CacheConfiguration input = ValidationSupportChain.CacheConfiguration.defaultValues();
+		Object result = postProcessor.postProcessAfterInitialization(
+				input, "validationSupportChainCacheConfiguration");
+
+		ValidationSupportChain.CacheConfiguration disabled =
+				ValidationSupportChain.CacheConfiguration.disabled();
+		ValidationSupportChain.CacheConfiguration actual = (ValidationSupportChain.CacheConfiguration) result;
+
+		assertEquals(disabled.getCacheSize(), actual.getCacheSize());
+		assertEquals(disabled.getCacheTimeout(), actual.getCacheTimeout());
+	}
+
+	@Test
+	void keepsCacheConfigurationWhenPropertyIsTrue() {
+		AppProperties properties = new AppProperties();
+		properties.getValidation().setSupport_chain_cache_enabled(true);
+
+		ValidationSupportChainCacheConfig config = new ValidationSupportChainCacheConfig();
+		BeanPostProcessor postProcessor =
+				config.validationSupportChainCacheConfigurationPostProcessor(properties);
+
+		ValidationSupportChain.CacheConfiguration input = ValidationSupportChain.CacheConfiguration.defaultValues();
+		Object result = postProcessor.postProcessAfterInitialization(
+				input, "validationSupportChainCacheConfiguration");
+
+		assertSame(input, result);
+	}
+}


### PR DESCRIPTION
This pull request introduces a new configuration option to control whether the validation support chain cache is enabled or disabled, making cache management more flexible and configurable through application properties. It also adds supporting configuration, documentation, and tests to ensure correct behavior.

**Configuration and Feature Enablement:**

* Added a new property `support_chain_cache_enabled` to the `Validation` section of `AppProperties`, with getter and setter methods, allowing the cache to be enabled or disabled via configuration. [[1]](diffhunk://#diff-79251bbeac3bb7f417a707bbda464fdfb2394f40bd88e43a9f5472e0ed351c83R965) [[2]](diffhunk://#diff-79251bbeac3bb7f417a707bbda464fdfb2394f40bd88e43a9f5472e0ed351c83R982-R989)
* Updated `application.yaml` and `application-cds.yaml` to document and allow configuration of the new `support_chain_cache_enabled` property under the `validation` section. [[1]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061L305-R308) [[2]](diffhunk://#diff-9c5b3c7b46760af8c32313631a0cd0ebe485349a5a2be3bded7d7fd546f83e9dR299)

**Implementation:**

* Introduced `ValidationSupportChainCacheConfig`, a new Spring configuration class that uses a `BeanPostProcessor` to disable the validation support chain cache if the new property is set to `false`.

**Testing:**

* Added `ValidationSupportChainCacheConfigTest` to verify that the cache configuration is correctly enabled or disabled based on the property value.