### PR TITLE
refactor: replace inline resource threshold resolution with direct property access

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -369,7 +369,7 @@ public class FhirServerConfigCommon {
 				"binary_storage_filesystem_base_directory must be provided when binary_storage_mode=FILESYSTEM");
 
 		FilesystemBinaryStorageSvcImpl filesystemSvc = new FilesystemBinaryStorageSvcImpl(baseDirectory);
-		Integer inlineResourceThreshold = resolveInlineResourceThreshold(appProperties);
+		Integer inlineResourceThreshold = appProperties.getBinary_storage_minimum_binary_size();
 		int minimumBinarySize =
 				inlineResourceThreshold == null ? DEFAULT_FILESYSTEM_INLINE_THRESHOLD : inlineResourceThreshold;
 		filesystemSvc.setMinimumBinarySize(minimumBinarySize);
@@ -395,15 +395,6 @@ public class FhirServerConfigCommon {
 			databaseSvc.setMaximumBinarySize(maxBinarySize.longValue());
 		}
 		return databaseSvc;
-	}
-
-	private Integer resolveInlineResourceThreshold(AppProperties appProperties) {
-		Integer inlineResourceThreshold = appProperties.getBinary_storage_minimum_binary_size();
-		if (inlineResourceThreshold == null
-				&& appProperties.getBinary_storage_mode() == AppProperties.BinaryStorageMode.FILESYSTEM) {
-			return DEFAULT_FILESYSTEM_INLINE_THRESHOLD;
-		}
-		return inlineResourceThreshold;
 	}
 
 	@Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -428,9 +428,9 @@ hapi:
     #   binary_storage_enabled: true
     #   binary_storage_mode: FILESYSTEM
     #   binary_storage_filesystem_base_directory: /binstore
-    # When binary_storage_mode is FILESYSTEM and this value is not set,
-    # the starter defaults to 102400 bytes so smaller binaries stay inline.
-    binary_storage_minimum_binary_size: 4000
+    #     When binary_storage_mode is FILESYSTEM and this value is not set,
+    #     the starter defaults to 102400 bytes so smaller binaries stay inline.
+    #   binary_storage_minimum_binary_size: 1_000_000
 
     # -------------------------------------------------------------------------------
     # P. Remote Terminology Service (disabled by default)


### PR DESCRIPTION
This pull request simplifies the configuration and code related to the minimum binary size threshold for filesystem binary storage. The main changes remove an unnecessary helper method and clarify the configuration example for users.

Configuration and code simplification:

* The `resolveInlineResourceThreshold` helper method was removed, and the code now directly uses `appProperties.getBinary_storage_minimum_binary_size()` when configuring the minimum binary size for filesystem storage in `FhirServerConfigCommon.java`. [[1]](diffhunk://#diff-fd6dcf03ea73119d9f990be724eae46d0232c2ff9264be408947a309367d712fL372-R372) [[2]](diffhunk://#diff-fd6dcf03ea73119d9f990be724eae46d0232c2ff9264be408947a309367d712fL400-L408)

Configuration documentation update:

* The example minimum binary size in `application.yaml` was updated from `4000` to a commented-out value of `1_000_000`, making it clearer for users how to set large thresholds and emphasizing that the value is optional.