### PR TITLE
fix(899): fixing missing slash

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/web/CustomContentFilesConfigurer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/web/CustomContentFilesConfigurer.java
@@ -19,8 +19,9 @@ public class CustomContentFilesConfigurer implements WebMvcConfigurer {
 
 	public CustomContentFilesConfigurer(AppProperties appProperties) {
 		customContentPath = appProperties.getCustom_content_path();
-		if (customContentPath.endsWith("/"))
-			customContentPath = customContentPath.substring(0, customContentPath.lastIndexOf('/'));
+		if (!customContentPath.endsWith("/")) {
+			customContentPath = customContentPath + "/";
+		}
 	}
 
 	@Override

--- a/src/main/java/ca/uhn/fhir/jpa/starter/web/WebAppFilesConfigurer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/web/WebAppFilesConfigurer.java
@@ -22,7 +22,9 @@ public class WebAppFilesConfigurer implements WebMvcConfigurer {
 
 	public WebAppFilesConfigurer(AppProperties appProperties) {
 		appContentPath = appProperties.getApp_content_path();
-		if (appContentPath.endsWith("/")) appContentPath = appContentPath.substring(0, appContentPath.lastIndexOf('/'));
+		if (!appContentPath.endsWith("/")) {
+			appContentPath = appContentPath + "/";
+		}
 	}
 
 	@Override
@@ -43,6 +45,9 @@ public class WebAppFilesConfigurer implements WebMvcConfigurer {
 	@Override
 	public void addViewControllers(@NotNull ViewControllerRegistry registry) {
 		String path = URI.create(appContentPath).getPath();
+		if (path.endsWith("/")) {
+			path = path.substring(0, path.length() - 1);
+		}
 		String lastSegment = path.substring(path.lastIndexOf('/') + 1);
 
 		registry.addViewController(WEB_CONTENT + "/" + lastSegment)


### PR DESCRIPTION
This pull request standardizes how custom and application content paths are handled in the `CustomContentFilesConfigurer` and `WebAppFilesConfigurer` classes. The main focus is to ensure that these paths consistently end with a trailing slash, which helps avoid issues when constructing resource handlers and view controllers. Additionally, the logic for extracting the last segment of the path in view controller registration is improved for reliability.

**Path normalization improvements:**

* Updated the constructor in `CustomContentFilesConfigurer` to ensure `customContentPath` always ends with a trailing slash, instead of removing one if present.
* Updated the constructor in `WebAppFilesConfigurer` to ensure `appContentPath` always ends with a trailing slash, instead of removing one if present.

**View controller registration fix:**

* Modified `addViewControllers` in `WebAppFilesConfigurer` to remove the trailing slash from the path before extracting the last segment, ensuring the correct segment is used for view controller mapping.…ir-jpaserver-starter/issues/899