### PR TITLE
Add a recursion guard to prevent infinite fallback

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
@@ -33,7 +33,7 @@ public class VersionedUrlFallbackValidationSupport implements IValidationSupport
 	private final Set<String> myUrlPrefixes;
 
 	// Recursion guard: Track URLs being fetched in this thread
-    private static final ThreadLocal<Set<String>> FETCHED_URLS = ThreadLocal.withInitial(HashSet::new);
+	private static final ThreadLocal<Set<String>> FETCHED_URLS = ThreadLocal.withInitial(HashSet::new);
 
 	/**
 	 * Creates a fallback validation support that only applies to URLs starting with the default prefix
@@ -70,17 +70,17 @@ public class VersionedUrlFallbackValidationSupport implements IValidationSupport
 
 	@Override
 	public IBaseResource fetchStructureDefinition(String theUrl) {
-        Set<String> fetched = FETCHED_URLS.get();
-        if (!fetched.add(theUrl)) {
-            ourLog.warn("Detected recursion while fetching StructureDefinition for '{}'", theUrl);
-            // Fail gracefully, let other supports handle it
-            return null;
-        }
-        try {
+		Set<String> fetched = FETCHED_URLS.get();
+		if (!fetched.add(theUrl)) {
+			ourLog.warn("Detected recursion while fetching StructureDefinition for '{}'", theUrl);
+			// Fail gracefully, let other supports handle it
+			return null;
+		}
+		try {
 			return doFetchWithFallback(theUrl, myChain::fetchStructureDefinition);
-        } finally {
-            fetched.remove(theUrl);
-        }
+		} finally {
+			fetched.remove(theUrl);
+		}
 	}
 
 	private <T extends IBaseResource> T doFetchWithFallback(String theUrl, Function<String, T> theFetcher) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupport.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -30,6 +31,9 @@ public class VersionedUrlFallbackValidationSupport implements IValidationSupport
 	private final FhirContext myFhirContext;
 	private final IValidationSupport myChain;
 	private final Set<String> myUrlPrefixes;
+
+	// Recursion guard: Track URLs being fetched in this thread
+    private static final ThreadLocal<Set<String>> FETCHED_URLS = ThreadLocal.withInitial(HashSet::new);
 
 	/**
 	 * Creates a fallback validation support that only applies to URLs starting with the default prefix
@@ -66,7 +70,17 @@ public class VersionedUrlFallbackValidationSupport implements IValidationSupport
 
 	@Override
 	public IBaseResource fetchStructureDefinition(String theUrl) {
-		return doFetchWithFallback(theUrl, myChain::fetchStructureDefinition);
+        Set<String> fetched = FETCHED_URLS.get();
+        if (!fetched.add(theUrl)) {
+            ourLog.warn("Detected recursion while fetching StructureDefinition for '{}'", theUrl);
+            // Fail gracefully, let other supports handle it
+            return null;
+        }
+        try {
+			return doFetchWithFallback(theUrl, myChain::fetchStructureDefinition);
+        } finally {
+            fetched.remove(theUrl);
+        }
 	}
 
 	private <T extends IBaseResource> T doFetchWithFallback(String theUrl, Function<String, T> theFetcher) {

--- a/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/validation/VersionedUrlFallbackValidationSupportTest.java
@@ -212,6 +212,33 @@ class VersionedUrlFallbackValidationSupportTest {
                 URL_PREFIX_STRUCTURE_DEFINITION);
     }
 
+    @Test
+    void testRecursionGuardPreventsStackOverflow() {
+
+        String versionedUrl = ORGANIZATION_URL_VERSIONED;
+        when(myChain.fetchStructureDefinition(versionedUrl)).thenAnswer(invocation -> mySvc.fetchStructureDefinition(versionedUrl));
+
+        assertDoesNotThrow(() -> {
+            var result = mySvc.fetchStructureDefinition(versionedUrl);
+            assertNull(result, "Recursion guard should return null instead of recursing infinitely");
+        });
+    }
+
+    @Test
+    void testRecursionGuardAllowsIndependentCalls() {
+
+        // If two different URLs are fetched, recursion guard should not interfere
+        String url1 = ORGANIZATION_URL_VERSIONED;
+        String url2 = CUSTOM_SD_URL_VERSIONED;
+
+        // Only stub the versioned URL that will actually be called in this test
+        when(myChain.fetchStructureDefinition(url1)).thenReturn(null);
+
+        assertNull(mySvc.fetchStructureDefinition(url1));
+        assertNull(mySvc.fetchStructureDefinition(url2)); // Will return null, no stubbing needed
+    }
+
+
     /**
      * Integration tests using real DefaultProfileValidationSupport instead of mocks.
      * This tests the actual fallback behavior with FHIR's built-in profiles.


### PR DESCRIPTION
This PR adds a recursion guard to VersionedUrlFallbackValidationSupport to prevent infinite recursion when a required StructureDefinition is missing from the validator context as reported in #938
