### PR TITLE
fix: compatibility fixes for Spring Boot 3.5.9 (Thymeleaf + resource handler)

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/web/CustomContentFilesConfigurer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/web/CustomContentFilesConfigurer.java
@@ -19,8 +19,7 @@ public class CustomContentFilesConfigurer implements WebMvcConfigurer {
 
 	public CustomContentFilesConfigurer(AppProperties appProperties) {
 		customContentPath = appProperties.getCustom_content_path();
-		if (!customContentPath.endsWith("/"))
-			customContentPath = customContentPath + "/";
+		if (!customContentPath.endsWith("/")) customContentPath = customContentPath + "/";
 	}
 
 	@Override

--- a/src/main/java/ca/uhn/fhir/jpa/starter/web/CustomContentFilesConfigurer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/web/CustomContentFilesConfigurer.java
@@ -19,8 +19,8 @@ public class CustomContentFilesConfigurer implements WebMvcConfigurer {
 
 	public CustomContentFilesConfigurer(AppProperties appProperties) {
 		customContentPath = appProperties.getCustom_content_path();
-		if (customContentPath.endsWith("/"))
-			customContentPath = customContentPath.substring(0, customContentPath.lastIndexOf('/'));
+		if (!customContentPath.endsWith("/"))
+			customContentPath = customContentPath + "/";
 	}
 
 	@Override

--- a/src/main/java/ca/uhn/fhir/jpa/starter/web/WebAppFilesConfigurer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/web/WebAppFilesConfigurer.java
@@ -32,7 +32,7 @@ public class WebAppFilesConfigurer implements WebMvcConfigurer {
 				try {
 					theRegistry
 							.addResourceHandler(WEB_CONTENT + "/**")
-							.addResourceLocations(new FileUrlResource(appContentPath));
+							.addResourceLocations(new FileUrlResource(appContentPath + "/"));
 				} catch (MalformedURLException e) {
 					throw new RuntimeException(e);
 				}

--- a/src/main/webapp/WEB-INF/templates/about.html
+++ b/src/main/webapp/WEB-INF/templates/about.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
-<head th:include="tmpl-head :: head">
+<head th:replace="~{tmpl-head :: head}">
     <title>About This Server</title>
 </head>
 
 <body>
 <form action="" method="get" id="outerForm">
-    <div th:replace="tmpl-navbar-top :: top"></div>
+    <div th:replace="~{tmpl-navbar-top :: top}"></div>
 
     <div class="container-fluid">
         <div class="row">
-            <div th:replace="tmpl-navbar-left :: left"></div>
+            <div th:replace="~{tmpl-navbar-left :: left}"></div>
 
             <div class="col-sm-9 col-sm-offset-3 col-md-9 col-md-offset-3 main">
 
-                <div th:replace="tmpl-banner :: banner"></div>
+                <div th:replace="~{tmpl-banner :: banner}"></div>
 
                 <div class="panel panel-default">
                     <div class="panel-heading">
@@ -56,7 +56,7 @@
         </div>
     </div>
 
-    <div th:replace="tmpl-footer :: footer"></div>
+    <div th:replace="~{tmpl-footer :: footer}"></div>
     </form>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **`about.html`**: migrates deprecated Thymeleaf syntax introduced by the Thymeleaf 3.1 bundle shipped with Spring Boot 3.5.9 — replaces `th:include` with `th:replace` and wraps all bare fragment expressions with the required `~{...}` syntax.
- **`CustomContentFilesConfigurer`**: fixes startup crash caused by Spring MVC 6.2 (Spring Boot 3.5.9) enforcing that all file-system resource locations end with a trailing slash — previously the constructor was explicitly stripping it. Formatting aligned with palantir-java-format.
- **`WebAppFilesConfigurer`**: same trailing-slash fix; the constructor is left unchanged (view controller URI logic needs the no-slash form), the slash is added only at the `addResourceLocations` call site.

## Root cause

Both issues were introduced by the same upgrade to Spring Boot 3.5.9:

1. Thymeleaf 3.1+ emits `WARN` for `th:include` and bare fragment expressions and will remove them in a future major version.
2. `ResourceHandlerUtils.assertResourceLocation` now throws `IllegalArgumentException` if a resource location URL does not end with `/`, causing an immediate startup crash.

The upstream `hapi-fhir-testpage-overlay` templates are already clean at 8.8.0 — no upstream template overrides are needed beyond `about.html`, which was a stale local copy from a pre-fix upstream version.

## Runtime impact

- No profile changes, no new environment variables, no port changes.
- The startup crash on `file:./custom` resource location is eliminated.
- Thymeleaf deprecation warnings on `/about` are eliminated.

## Test plan

- [ ] Open `http://localhost:8080/about` and confirm no Thymeleaf `WARN` lines in the log.
- [ ] Run `mvn verify` to confirm no regressions in unit/integration tests.