### PR TITLE
feat(config): expose RestfulClientFactory timeouts and pool settings via hapi.fhir.client

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -135,12 +135,28 @@ public class AppProperties {
 
 	private boolean allow_database_validation_override = false;
 
+	/**
+	 * Outbound HTTP client settings applied to the HAPI {@code FhirContext} RestfulClientFactory.
+	 * These govern every outbound FHIR call the server makes on its own behalf: remote terminology
+	 * validation, IG fetches, subscription delivery checks, and the web tester UI.
+	 * All timeout values are in milliseconds; pool values are connection counts.
+	 */
+	private Client client = new Client();
+
 	public boolean getAllow_database_validation_override() {
 		return allow_database_validation_override;
 	}
 
 	public void setAllow_database_validation_override(boolean allow_database_validation_override) {
 		this.allow_database_validation_override = allow_database_validation_override;
+	}
+
+	public Client getClient() {
+		return client;
+	}
+
+	public void setClient(Client client) {
+		this.client = client;
 	}
 
 	public List<String> getCustomInterceptorClasses() {
@@ -1286,6 +1302,103 @@ public class AppProperties {
 
 		public void setIndex_prefix(String index_prefix) {
 			this.index_prefix = index_prefix;
+		}
+	}
+
+	/**
+	 * Outbound HTTP client settings applied to {@code FhirContext.getRestfulClientFactory()}.
+	 *
+	 * <p>Default values mirror the upstream HAPI constants in
+	 * {@code IRestfulClientFactory}: 10 000 ms for all timeouts, 20 for pool sizes.
+	 * Override these via {@code hapi.fhir.client.*} in {@code application.yaml} (or
+	 * the equivalent environment-variable form) whenever the server makes outbound
+	 * FHIR calls to slow or remote services — e.g. remote terminology servers,
+	 * IG package registries, or CDS Hooks upstream providers.</p>
+	 */
+	public static class Client {
+
+		/**
+		 * Maximum time (ms) to wait for data on an established socket before
+		 * giving up. Corresponds to {@code IRestfulClientFactory.setSocketTimeout}.
+		 */
+		private Integer socket_timeout = 10000;
+
+		/**
+		 * Maximum time (ms) to wait while establishing a TCP connection.
+		 * Corresponds to {@code IRestfulClientFactory.setConnectTimeout}.
+		 */
+		private Integer connect_timeout = 10000;
+
+		/**
+		 * Maximum time (ms) to wait for a connection to be leased from the pool.
+		 * Corresponds to {@code IRestfulClientFactory.setConnectionRequestTimeout}.
+		 */
+		private Integer connection_request_timeout = 10000;
+
+		/**
+		 * Time-to-live (ms) for persistent connections in the pool.
+		 * Corresponds to {@code IRestfulClientFactory.setConnectionTimeToLive}.
+		 */
+		private Integer connection_ttl = 5000;
+
+		/**
+		 * Maximum total number of connections in the HTTP connection pool.
+		 * Corresponds to {@code IRestfulClientFactory.setPoolMaxTotal}.
+		 */
+		private Integer pool_max_total = 20;
+
+		/**
+		 * Maximum connections per route (target host) in the HTTP connection pool.
+		 * Corresponds to {@code IRestfulClientFactory.setPoolMaxPerRoute}.
+		 */
+		private Integer pool_max_per_route = 20;
+
+		public Integer getSocket_timeout() {
+			return socket_timeout;
+		}
+
+		public void setSocket_timeout(Integer socket_timeout) {
+			this.socket_timeout = socket_timeout;
+		}
+
+		public Integer getConnect_timeout() {
+			return connect_timeout;
+		}
+
+		public void setConnect_timeout(Integer connect_timeout) {
+			this.connect_timeout = connect_timeout;
+		}
+
+		public Integer getConnection_request_timeout() {
+			return connection_request_timeout;
+		}
+
+		public void setConnection_request_timeout(Integer connection_request_timeout) {
+			this.connection_request_timeout = connection_request_timeout;
+		}
+
+		public Integer getConnection_ttl() {
+			return connection_ttl;
+		}
+
+		public void setConnection_ttl(Integer connection_ttl) {
+			this.connection_ttl = connection_ttl;
+		}
+
+		public Integer getPool_max_total() {
+			return pool_max_total;
+		}
+
+		public void setPool_max_total(Integer pool_max_total) {
+			this.pool_max_total = pool_max_total;
+		}
+
+		public Integer getPool_max_per_route() {
+			return pool_max_per_route;
+		}
+
+		public void setPool_max_per_route(Integer pool_max_per_route) {
+			this.pool_max_per_route = pool_max_per_route;
 		}
 	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -59,6 +59,7 @@ import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
 import ca.uhn.fhir.narrative2.NullNarrativeGenerator;
 import ca.uhn.fhir.rest.api.IResourceSupportedSvc;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
 import ca.uhn.fhir.rest.openapi.OpenApiInterceptor;
 import ca.uhn.fhir.rest.server.ApacheProxyAddressStrategy;
 import ca.uhn.fhir.rest.server.ETagSupportEnum;
@@ -86,6 +87,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 import org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy;
@@ -133,6 +135,36 @@ public class StarterJpaConfig {
 		pagingProvider.setDefaultPageSize(appProperties.getDefault_page_size());
 		pagingProvider.setMaximumPageSize(appProperties.getMax_page_size());
 		return pagingProvider;
+	}
+
+	/**
+	 * Applies outbound HTTP client settings from {@code hapi.fhir.client.*} to the shared
+	 * {@link FhirContext} RestfulClientFactory.
+	 *
+	 * <p>The factory is used for every FHIR call the server makes on its own behalf:
+	 * remote terminology validation, IG package fetches, the web tester UI (HomeRequest),
+	 * and any custom interceptor or provider that calls
+	 * {@code fhirContext.newRestfulGenericClient(...)}. Configuring these values globally
+	 * here avoids scattering {@code getRestfulClientFactory().setSocketTimeout(...)} calls
+	 * across individual components.
+	 *
+	 * <p>All settings default to the upstream HAPI constants defined in
+	 * {@link IRestfulClientFactory} (10 000 ms for timeouts, 20 for pool sizes) so
+	 * existing deployments are unaffected unless they explicitly override via YAML or
+	 * environment variables.
+	 */
+	@Bean
+	public ApplicationRunner restfulClientFactoryConfigurer(FhirContext fhirContext, AppProperties appProperties) {
+		return args -> {
+			AppProperties.Client cfg = appProperties.getClient();
+			IRestfulClientFactory factory = fhirContext.getRestfulClientFactory();
+			factory.setSocketTimeout(cfg.getSocket_timeout());
+			factory.setConnectTimeout(cfg.getConnect_timeout());
+			factory.setConnectionRequestTimeout(cfg.getConnection_request_timeout());
+			factory.setConnectionTimeToLive(cfg.getConnection_ttl());
+			factory.setPoolMaxTotal(cfg.getPool_max_total());
+			factory.setPoolMaxPerRoute(cfg.getPool_max_per_route());
+		};
 	}
 
 	@Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -505,3 +505,24 @@ hapi:
         server_address: 'http://localhost:8080/fhir'
         refuse_to_fetch_third_party_urls: false
         fhir_version: R4
+
+    # -------------------------------------------------------------------------------
+    # T. Outbound HTTP client (RestfulClientFactory)
+    # -------------------------------------------------------------------------------
+    # These settings are applied once at startup to FhirContext.getRestfulClientFactory()
+    # and govern every outbound FHIR HTTP call the server makes on its own behalf:
+    #   - Remote terminology validation  (hapi.fhir.remote_terminology_service_*)
+    #   - IG / package registry fetches  (hapi.fhir.implementationGuides)
+    #   - Web tester UI (HomeRequest)
+    #   - Any custom interceptor/provider calling fhirContext.newRestfulGenericClient()
+    #
+    # All values below show the defaults (matching IRestfulClientFactory constants).
+    # Uncomment and adjust for slow or remote upstream services.
+    #
+    # client:
+    #   socket_timeout: 10000             # ms — max idle time waiting for data on an open socket
+    #   connect_timeout: 10000            # ms — max time to establish a TCP connection
+    #   connection_request_timeout: 10000 # ms — max time waiting for a connection from the pool
+    #   connection_ttl: 5000              # ms — time-to-live for pooled persistent connections
+    #   pool_max_total: 20                # total connections across all routes
+    #   pool_max_per_route: 20            # connections per target host


### PR DESCRIPTION
## Summary

- Adds a new `hapi.fhir.client` configuration block that exposes all six `IRestfulClientFactory` settings (`socket_timeout`, `connect_timeout`, `connection_request_timeout`, `connection_ttl`, `pool_max_total`, `pool_max_per_route`) as bindable YAML/environment-variable properties.
- Wires these into the shared `FhirContext` at startup via a new `@Bean ApplicationRunner restfulClientFactoryConfigurer` in `StarterJpaConfig`.
- Documents the new section in `application.yaml` with inline comments explaining which components are affected.

## Motivation

Previously the outbound HTTP client used for remote terminology validation, IG fetches, the web tester UI (`HomeRequest`), and any custom provider calling `fhirContext.newRestfulGenericClient(...)` could only be tuned by editing Java code (a pattern seen in integration tests: `ourCtx.getRestfulClientFactory().setSocketTimeout(...)`). Operators deploying against slow or high-latency remote services had no way to raise these limits without recompiling.

## Changes

### `AppProperties.java`
- New `static class Client` with six fields defaulting to the matching `IRestfulClientFactory` constants (10 000 ms timeouts, 20 pool sizes) — existing deployments are **not affected** unless they explicitly set the new keys.
- Field `private Client client = new Client()` + getter/setter bound under `hapi.fhir.client`.

### `StarterJpaConfig.java`
- New `@Bean ApplicationRunner restfulClientFactoryConfigurer(FhirContext, AppProperties)` that applies all six values to `fhirContext.getRestfulClientFactory()` at startup.

### `application.yaml`
- New commented-out section **T — Outbound HTTP client (RestfulClientFactory)** with all keys, their defaults, and a description of the affected call paths.

## Runtime impact

- No new profiles, ports, or required environment variables.
- All defaults match the upstream `IRestfulClientFactory` constants — zero behavioural change for deployments that do not set `hapi.fhir.client.*`.
- To raise the socket timeout to 60 s (e.g. for a slow remote terminology server):
  ```yaml
  hapi:
    fhir:
      client:
        socket_timeout: 60000
  ```
  Or via env var: `HAPI_FHIR_CLIENT_SOCKET_TIMEOUT=60000`

## Test plan

- [x] `mvn compile` — clean
- [x] `mvn test` — 41/42 pass; `ReproduceIssueTest` fails with `Resource location does not end with slash: file:custom`, a pre-existing issue on `master` unrelated to this change
- [x] `mvn spotless:check` (JDK 21) — BUILD SUCCESS