### PR TITLE
Adding support for JS prototyping using GraalJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,75 @@ The `$install` operation is triggered with a POST to `[server]/ImplementationGui
 }
 ```
 
+## Server-side JavaScript execution ($execute-javascript)
+
+The R4 system-level operation `$execute-javascript` runs a **server-side** JavaScript file (via the standalone Nashorn engine) to transform FHIR resources. Callers do **not** send code — they reference a script by name that an administrator has placed in a configured directory. The script receives the input resources as a JavaScript array called `input` and returns a single resource object or an array of resource objects, which are returned as `return` parameters.
+
+Security model:
+
+- Disabled by default; enable with `hapi.fhir.javascript_execution_enabled=true`.
+- The `script` parameter is resolved to a file inside `hapi.fhir.javascript_execution_scripts_dir` only (bare file name, no path traversal).
+- Each script runs in a Nashorn sandbox that blocks access to all Java classes (no JVM/filesystem/network reach).
+- Each invocation is bounded by `hapi.fhir.javascript_execution_timeout_seconds` (default `30`); a script that overruns is stopped and the call fails.
+
+Configuration:
+
+```yaml
+hapi:
+  fhir:
+    javascript_execution_enabled: true
+    javascript_execution_scripts_dir: /scripts
+    javascript_execution_timeout_seconds: 30
+```
+
+Inputs may be supplied two ways (combined into `input` in order — inline resources first, then resolved references):
+
+- `resource` (0..*) — an inline FHIR resource.
+- `reference` (0..*) — a literal reference (e.g. `Patient/123`) that the server reads before the script runs.
+
+Example request body to `POST [base]/$execute-javascript`:
+
+```json
+{
+  "resourceType": "Parameters",
+  "parameter": [
+    { "name": "script", "valueString": "add-active" },
+    { "name": "resource", "resource": { "resourceType": "Patient", "active": false, "name": [{ "family": "Doe" }] } },
+    { "name": "reference", "valueReference": { "reference": "Patient/123" } }
+  ]
+}
+```
+
+### One-liner for quickly testing $execute-javascript with Docker
+
+This feature lives in this source tree, so build the local image (it is not part of the published Docker Hub image). First create a sample script:
+
+```bash
+mkdir -p scripts && cat > scripts/add-active.js <<'EOF'
+// Sets active=true on every input resource and returns them.
+input.map(function (resource) {
+  resource.active = true;
+  return resource;
+});
+EOF
+```
+
+Then build and run, mounting the scripts directory and enabling the feature:
+
+```bash
+docker run -p 8080:8080 -v "$(pwd)/scripts:/scripts" -e "hapi.fhir.javascript_execution_enabled=true" -e "hapi.fhir.javascript_execution_scripts_dir=/scripts" hapiproject/hapi:latest
+```
+
+Once it is up, invoke the operation:
+
+```bash
+curl -s -X POST 'http://localhost:8080/fhir/$execute-javascript' \
+  -H 'Content-Type: application/fhir+json' \
+  -d '{"resourceType":"Parameters","parameter":[{"name":"script","valueString":"add-active"},{"name":"resource","resource":{"resourceType":"Patient","active":false,"name":[{"family":"Doe"}]}}]}'
+```
+
+The response is a `Parameters` resource whose `return` parameter holds the transformed `Patient` with `active` set to `true`.
+
 ## Enable OpenTelemetry auto-instrumentation
 
 The container image includes the [OpenTelemetry Java auto-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)

--- a/README.md
+++ b/README.md
@@ -666,13 +666,13 @@ The `$install` operation is triggered with a POST to `[server]/ImplementationGui
 
 ## Server-side JavaScript execution ($execute-javascript)
 
-The R4 system-level operation `$execute-javascript` runs a **server-side** JavaScript file (via the standalone Nashorn engine) to transform FHIR resources. Callers do **not** send code — they reference a script by name that an administrator has placed in a configured directory. The script receives the input resources as a JavaScript array called `input` and returns a single resource object or an array of resource objects, which are returned as `return` parameters.
+The R4 system-level operation `$execute-javascript` runs a **server-side** JavaScript file (via the embedded GraalJS engine) to transform FHIR resources. Callers do **not** send code — they reference a script by name that an administrator has placed in a configured directory. The script receives the input resources as a JavaScript array called `input` and returns a single resource object or an array of resource objects, which are returned as `return` parameters.
 
 Security model:
 
 - Disabled by default; enable with `hapi.fhir.javascript_execution_enabled=true`.
 - The `script` parameter is resolved to a file inside `hapi.fhir.javascript_execution_scripts_dir` only (bare file name, no path traversal).
-- Each script runs in a Nashorn sandbox that blocks access to all Java classes (no JVM/filesystem/network reach).
+- Each script runs in a GraalJS sandbox created with no host access — Java classes, the filesystem, the network and thread creation are all denied (no JVM/filesystem/network reach).
 - Each invocation is bounded by `hapi.fhir.javascript_execution_timeout_seconds` (default `30`); a script that overruns is stopped and the call fails.
 
 Configuration:

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Standalone Nashorn JavaScript engine (removed from the JDK in Java 15) -->
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.7</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -439,11 +439,13 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Standalone Nashorn JavaScript engine (removed from the JDK in Java 15) -->
+        <!-- GraalJS — embeddable JavaScript engine used by $execute-javascript. The 23.0.x line is
+             the last that supports JDK 17 (23.1+ requires JDK 21). Pulls in the polyglot Context API
+             via graal-sdk transitively; runs in interpreter mode on a stock (non-GraalVM) JDK. -->
         <dependency>
-            <groupId>org.openjdk.nashorn</groupId>
-            <artifactId>nashorn-core</artifactId>
-            <version>15.7</version>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>23.0.8</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -52,6 +52,7 @@ import ca.uhn.fhir.jpa.starter.annotations.OnImplementationGuidesPresent;
 import ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationInterceptorFactory;
 import ca.uhn.fhir.jpa.starter.elastic.ElasticsearchBootSvcImpl;
 import ca.uhn.fhir.jpa.starter.ig.IImplementationGuideOperationProvider;
+import ca.uhn.fhir.jpa.starter.javascript.JavaScriptExecutionR4OperationProvider;
 import ca.uhn.fhir.jpa.subscription.util.SubscriptionDebugLogInterceptor;
 import ca.uhn.fhir.jpa.util.ResourceCountCache;
 import ca.uhn.fhir.mdm.provider.MdmProviderLoader;
@@ -358,6 +359,7 @@ public class StarterJpaConfig {
 			ApplicationContext appContext,
 			Optional<IpsOperationProvider> theIpsOperationProvider,
 			Optional<IImplementationGuideOperationProvider> implementationGuideOperationProvider,
+			Optional<JavaScriptExecutionR4OperationProvider> javaScriptExecutionOperationProvider,
 			DiffProvider diffProvider) {
 		RestfulServer fhirServer = new RestfulServer(fhirSystemDao.getContext());
 
@@ -422,6 +424,8 @@ public class StarterJpaConfig {
 		fhirServer.registerInterceptor(loggingInterceptor);
 
 		implementationGuideOperationProvider.ifPresent(fhirServer::registerProvider);
+
+		javaScriptExecutionOperationProvider.ifPresent(fhirServer::registerProvider);
 
 		/*
 		 * If you are hosting this server at a specific DNS name, the server will try to

--- a/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
@@ -12,13 +12,13 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graalvm.polyglot.Context;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
-import org.graalvm.polyglot.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -275,7 +275,9 @@ public class JavaScriptExecutionR4OperationProvider {
 		theContext.eval("js", "var input = JSON.parse(__inputJson);");
 		org.graalvm.polyglot.Value result = theContext.eval("js", theScript);
 		bindings.putMember("__result", result);
-		return theContext.eval("js", "JSON.stringify(__result === undefined ? null : __result)").asString();
+		return theContext
+				.eval("js", "JSON.stringify(__result === undefined ? null : __result)")
+				.asString();
 	}
 
 	/** Parses the script's JSON result (single object or array) back into FHIR resources. */

--- a/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
@@ -18,8 +18,7 @@ import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.hl7.fhir.r4.model.StringType;
-import org.openjdk.nashorn.api.scripting.ClassFilter;
-import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import org.graalvm.polyglot.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,14 +36,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
-import javax.script.SimpleScriptContext;
 
 /**
- * Custom R4 system-level operation that runs a server-side JavaScript file (via the standalone
- * Nashorn engine) to transform FHIR resources.
+ * Custom R4 system-level operation that runs a server-side JavaScript file (via the embedded
+ * GraalJS engine) to transform FHIR resources.
  *
  * <p>Callers do <b>not</b> supply the JavaScript itself — they reference one of the scripts the
  * server administrator has placed in the configured scripts directory
@@ -82,11 +77,12 @@ import javax.script.SimpleScriptContext;
  * resolved to a file inside the configured scripts directory — the name is validated to a bare
  * file name and the resolved path is verified to stay within that directory, so callers cannot
  * traverse the filesystem or execute code that the administrator has not installed. As
- * defense-in-depth, the Nashorn engine is sandboxed with a {@link ClassFilter} that blocks access
- * to all Java classes, so scripts are limited to pure JavaScript and cannot reach the host JVM,
- * filesystem or network. Each invocation is also bounded by an execution timeout
- * ({@code hapi.fhir.javascript_execution_timeout_seconds}, default 30s); a script that overruns is
- * stopped and the call fails.
+ * defense-in-depth, each script runs in a fresh GraalJS {@link Context} created with no host access
+ * — Java class lookup, filesystem, network and thread creation are all denied by default — so
+ * scripts are limited to pure JavaScript and cannot reach the host JVM, filesystem or network. Each
+ * invocation is also bounded by an execution timeout
+ * ({@code hapi.fhir.javascript_execution_timeout_seconds}, default 30s); a script that overruns has
+ * its context cancelled and the call fails.
  */
 @Conditional({OnR4Condition.class})
 @ConditionalOnProperty(name = "hapi.fhir.javascript_execution_enabled", havingValue = "true")
@@ -95,16 +91,12 @@ public class JavaScriptExecutionR4OperationProvider {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(JavaScriptExecutionR4OperationProvider.class);
 
-	/** Denies the script access to every Java class, keeping execution to pure JavaScript. */
-	private static final ClassFilter DENY_ALL_JAVA_CLASSES = className -> false;
-
 	/** A script name is a bare file name (optionally ending in {@code .js}) — never a path. */
 	private static final Pattern SCRIPT_NAME_PATTERN = Pattern.compile("[A-Za-z0-9_-]+(\\.js)?");
 
 	private final FhirContext myFhirContext;
 	private final DaoRegistry myDaoRegistry;
 	private final ObjectMapper myObjectMapper = new ObjectMapper();
-	private final NashornScriptEngineFactory myEngineFactory = new NashornScriptEngineFactory();
 	private final Path myScriptsDir;
 	private final long myTimeoutSeconds;
 
@@ -224,17 +216,23 @@ public class JavaScriptExecutionR4OperationProvider {
 
 	/**
 	 * Runs the script on a dedicated daemon thread and enforces {@link #myTimeoutSeconds}. If the
-	 * script overruns it is forcibly stopped — safe here because each engine is fresh and isolated
-	 * and the sandbox denies all Java access, so a stuck script holds no shared locks or state.
+	 * script overruns, the GraalJS context is cancelled from this thread — even a tight CPU-bound
+	 * loop is unwound cleanly, with no need to forcibly stop the thread. Each context is fresh and
+	 * isolated and the sandbox denies all host access, so a cancelled script holds no shared state.
 	 */
 	private String runScript(String theScript, String theInputJson) {
 		AtomicReference<String> resultRef = new AtomicReference<>();
 		AtomicReference<Exception> errorRef = new AtomicReference<>();
 
+		// No host access: scripts cannot reach Java classes, the filesystem, the network or threads.
+		Context context = Context.newBuilder("js")
+				.option("engine.WarnInterpreterOnly", "false")
+				.build();
+
 		Thread worker = new Thread(
 				() -> {
 					try {
-						resultRef.set(evaluate(theScript, theInputJson));
+						resultRef.set(evaluate(context, theScript, theInputJson));
 					} catch (Exception e) {
 						errorRef.set(e);
 					}
@@ -247,55 +245,37 @@ public class JavaScriptExecutionR4OperationProvider {
 			worker.join(TimeUnit.SECONDS.toMillis(myTimeoutSeconds));
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
-			stopWorker(worker);
+			context.close(true);
 			throw new InternalErrorException("Interrupted while waiting for script to complete.", e);
 		}
 
 		if (worker.isAlive()) {
-			stopWorker(worker);
+			// Cancel the in-flight evaluation; this unblocks the worker by throwing inside the script.
+			context.close(true);
 			throw new InvalidRequestException("JavaScript execution timed out after " + myTimeoutSeconds + " seconds.");
 		}
 
+		context.close();
+
 		Exception error = errorRef.get();
 		if (error != null) {
-			// A ScriptException covers syntax/runtime JS errors; a RuntimeException covers e.g. the
-			// ClassFilter blocking a Java class access. Either way it is caller error -> 400, not 500.
+			// A PolyglotException covers syntax/runtime JS errors as well as the sandbox blocking host
+			// access (e.g. an undefined 'Java'). Either way it is caller error -> 400, not 500.
 			ourLog.debug("JavaScript execution failed", error);
 			throw new InvalidRequestException("JavaScript execution failed: " + error.getMessage(), error);
 		}
 		return resultRef.get();
 	}
 
-	/** Evaluates the script in a fresh, sandboxed Nashorn engine and returns the JSON result. */
-	private String evaluate(String theScript, String theInputJson) throws ScriptException {
-		ScriptEngine engine = myEngineFactory.getScriptEngine(DENY_ALL_JAVA_CLASSES);
-		ScriptContext context = new SimpleScriptContext();
-		engine.setContext(context);
-		engine.put("__inputJson", theInputJson);
+	/** Evaluates the script in the given fresh, sandboxed GraalJS context and returns the JSON result. */
+	private String evaluate(Context theContext, String theScript, String theInputJson) {
+		org.graalvm.polyglot.Value bindings = theContext.getBindings("js");
+		bindings.putMember("__inputJson", theInputJson);
 
-		engine.eval("var input = JSON.parse(__inputJson);");
-		Object result = engine.eval(theScript);
-		engine.put("__result", result);
-		return (String) engine.eval("JSON.stringify(__result === undefined ? null : __result)");
-	}
-
-	/** Interrupts the worker, and forcibly stops it if it ignores interruption (e.g. a tight loop). */
-	@SuppressWarnings({"deprecation", "removal"})
-	private void stopWorker(Thread theWorker) {
-		theWorker.interrupt();
-		try {
-			theWorker.join(1000);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-		}
-		if (theWorker.isAlive()) {
-			try {
-				// Nashorn does not interrupt CPU-bound loops; ThreadDeath is the only reliable stop.
-				theWorker.stop();
-			} catch (Throwable t) {
-				ourLog.warn("Unable to forcibly stop timed-out script thread", t);
-			}
-		}
+		theContext.eval("js", "var input = JSON.parse(__inputJson);");
+		org.graalvm.polyglot.Value result = theContext.eval("js", theScript);
+		bindings.putMember("__result", result);
+		return theContext.eval("js", "JSON.stringify(__result === undefined ? null : __result)").asString();
 	}
 
 	/** Parses the script's JSON result (single object or array) back into FHIR resources. */

--- a/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
@@ -1,0 +1,342 @@
+package ca.uhn.fhir.jpa.starter.javascript;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.starter.annotations.OnR4Condition;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OperationParam;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
+import org.openjdk.nashorn.api.scripting.ClassFilter;
+import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Service;
+
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import javax.script.SimpleScriptContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+/**
+ * Custom R4 system-level operation that runs a server-side JavaScript file (via the standalone
+ * Nashorn engine) to transform FHIR resources.
+ *
+ * <p>Callers do <b>not</b> supply the JavaScript itself — they reference one of the scripts the
+ * server administrator has placed in the configured scripts directory
+ * ({@code hapi.fhir.javascript_execution_scripts_dir}). This keeps the set of executable code
+ * fixed and vetted, instead of accepting arbitrary code over the wire.
+ *
+ * <p>Invoke it as {@code POST [base]/$execute-javascript} with a {@code Parameters} body carrying a
+ * {@code script} (the file name, with or without the {@code .js} suffix), any number of inline
+ * {@code resource} parameters, and any number of {@code reference} parameters — literal references
+ * the server reads before the script runs, e.g.
+ *
+ * <pre>{@code
+ * {
+ *   "resourceType": "Parameters",
+ *   "parameter": [
+ *     { "name": "script", "valueString": "merge-patients" },
+ *     { "name": "resource", "resource": { "resourceType": "Patient", "id": "1" } },
+ *     { "name": "reference", "valueReference": { "reference": "Patient/2" } }
+ *   ]
+ * }
+ * }</pre>
+ *
+ * <p>Inside the script:
+ * <ul>
+ *   <li>{@code input} is a JavaScript array of the input resources (parsed JSON objects): the
+ *       inline {@code resource} parameters first, followed by the resources resolved from the
+ *       {@code reference} parameters, in declared order — possibly empty if none were sent.</li>
+ *   <li>The value the script evaluates to is collected as output. It may be a single resource
+ *       object or an array of resource objects. Each element is parsed back into a FHIR resource
+ *       and returned under a {@code return} parameter of the response {@code Parameters}.</li>
+ * </ul>
+ *
+ * <p><b>Security:</b> this provider is disabled unless
+ * {@code hapi.fhir.javascript_execution_enabled=true}. The {@code script} parameter is only ever
+ * resolved to a file inside the configured scripts directory — the name is validated to a bare
+ * file name and the resolved path is verified to stay within that directory, so callers cannot
+ * traverse the filesystem or execute code that the administrator has not installed. As
+ * defense-in-depth, the Nashorn engine is sandboxed with a {@link ClassFilter} that blocks access
+ * to all Java classes, so scripts are limited to pure JavaScript and cannot reach the host JVM,
+ * filesystem or network. Each invocation is also bounded by an execution timeout
+ * ({@code hapi.fhir.javascript_execution_timeout_seconds}, default 30s); a script that overruns is
+ * stopped and the call fails.
+ */
+@Conditional({OnR4Condition.class})
+@ConditionalOnProperty(name = "hapi.fhir.javascript_execution_enabled", havingValue = "true")
+@Service
+public class JavaScriptExecutionR4OperationProvider {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(JavaScriptExecutionR4OperationProvider.class);
+
+	/** Denies the script access to every Java class, keeping execution to pure JavaScript. */
+	private static final ClassFilter DENY_ALL_JAVA_CLASSES = className -> false;
+
+	/** A script name is a bare file name (optionally ending in {@code .js}) — never a path. */
+	private static final Pattern SCRIPT_NAME_PATTERN = Pattern.compile("[A-Za-z0-9_-]+(\\.js)?");
+
+	private final FhirContext myFhirContext;
+	private final DaoRegistry myDaoRegistry;
+	private final ObjectMapper myObjectMapper = new ObjectMapper();
+	private final NashornScriptEngineFactory myEngineFactory = new NashornScriptEngineFactory();
+	private final Path myScriptsDir;
+	private final long myTimeoutSeconds;
+
+	public JavaScriptExecutionR4OperationProvider(
+			FhirContext theFhirContext,
+			DaoRegistry theDaoRegistry,
+			@Value("${hapi.fhir.javascript_execution_scripts_dir:}") String theScriptsDir,
+			@Value("${hapi.fhir.javascript_execution_timeout_seconds:30}") long theTimeoutSeconds) {
+		this.myFhirContext = theFhirContext;
+		this.myDaoRegistry = theDaoRegistry;
+		this.myScriptsDir = (theScriptsDir == null || theScriptsDir.isBlank())
+				? null
+				: Paths.get(theScriptsDir).toAbsolutePath().normalize();
+		this.myTimeoutSeconds = theTimeoutSeconds;
+	}
+
+	@Operation(name = "$execute-javascript", idempotent = false)
+	public Parameters executeJavascript(
+			@OperationParam(name = "script", min = 1, max = 1) StringType theScriptName,
+			@OperationParam(name = "resource", min = 0, max = OperationParam.MAX_UNLIMITED)
+					List<IBaseResource> theInputResources,
+			@OperationParam(name = "reference", min = 0, max = OperationParam.MAX_UNLIMITED)
+					List<Reference> theReferences,
+			RequestDetails theRequestDetails) {
+
+		if (theScriptName == null || theScriptName.isEmpty()) {
+			throw new InvalidRequestException("A non-empty 'script' parameter (the script name) is required.");
+		}
+
+		String script = loadScript(theScriptName.getValue());
+
+		// 'input' = inline 'resource' parameters first, then the resources resolved from the literal
+		// 'reference' parameters (read from the server before the script runs), in declared order.
+		List<IBaseResource> inputs = new ArrayList<>();
+		if (theInputResources != null) {
+			inputs.addAll(theInputResources);
+		}
+		if (theReferences != null) {
+			for (Reference reference : theReferences) {
+				inputs.add(resolveReference(reference, theRequestDetails));
+			}
+		}
+
+		String resultJson = runScript(script, serializeInput(inputs));
+
+		Parameters response = new Parameters();
+		for (Resource resource : parseOutputResources(resultJson)) {
+			response.addParameter().setName("return").setResource(resource);
+		}
+		return response;
+	}
+
+	/** Reads the resource named by a literal reference (e.g. {@code Patient/123}) from the server. */
+	private IBaseResource resolveReference(Reference theReference, RequestDetails theRequestDetails) {
+		String reference = theReference == null ? null : theReference.getReference();
+		if (reference == null || reference.isBlank()) {
+			throw new InvalidRequestException(
+					"Each 'reference' parameter must contain a literal reference such as 'Patient/123'.");
+		}
+
+		IdType id = new IdType(reference);
+		if (!id.hasResourceType() || !id.hasIdPart()) {
+			throw new InvalidRequestException("Not a literal reference (expected '<Type>/<id>'): " + reference);
+		}
+		if (!myDaoRegistry.isResourceTypeSupported(id.getResourceType())) {
+			throw new InvalidRequestException("Unsupported resource type in reference: " + reference);
+		}
+
+		IFhirResourceDao<?> dao = myDaoRegistry.getResourceDao(id.getResourceType());
+		return dao.read(id, theRequestDetails);
+	}
+
+	/**
+	 * Resolves a caller-supplied script name to a file inside the configured scripts directory,
+	 * rejecting anything that is not a plain name within that directory.
+	 */
+	private String loadScript(String theScriptName) {
+		if (myScriptsDir == null) {
+			throw new InvalidRequestException(
+					"Server-side script execution is not configured (hapi.fhir.javascript_execution_scripts_dir).");
+		}
+		if (!SCRIPT_NAME_PATTERN.matcher(theScriptName).matches()) {
+			throw new InvalidRequestException("Invalid script name: " + theScriptName);
+		}
+
+		String fileName = theScriptName.endsWith(".js") ? theScriptName : theScriptName + ".js";
+		Path scriptPath = myScriptsDir.resolve(fileName).normalize();
+		// Defense-in-depth: even after name validation, confirm we never escaped the base directory.
+		if (!scriptPath.startsWith(myScriptsDir)) {
+			throw new InvalidRequestException("Invalid script name: " + theScriptName);
+		}
+		if (!Files.isRegularFile(scriptPath)) {
+			throw new InvalidRequestException("Unknown script: " + theScriptName);
+		}
+
+		try {
+			return Files.readString(scriptPath, StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new InternalErrorException("Failed to read script '" + theScriptName + "': " + e.getMessage(), e);
+		}
+	}
+
+	/** Serializes the input resources into a single JavaScript-parseable JSON array string. */
+	private String serializeInput(List<IBaseResource> theInputResources) {
+		IParser parser = myFhirContext.newJsonParser();
+		StringBuilder sb = new StringBuilder("[");
+		if (theInputResources != null) {
+			for (int i = 0; i < theInputResources.size(); i++) {
+				if (i > 0) {
+					sb.append(',');
+				}
+				sb.append(parser.encodeResourceToString(theInputResources.get(i)));
+			}
+		}
+		return sb.append(']').toString();
+	}
+
+	/**
+	 * Runs the script on a dedicated daemon thread and enforces {@link #myTimeoutSeconds}. If the
+	 * script overruns it is forcibly stopped — safe here because each engine is fresh and isolated
+	 * and the sandbox denies all Java access, so a stuck script holds no shared locks or state.
+	 */
+	private String runScript(String theScript, String theInputJson) {
+		AtomicReference<String> resultRef = new AtomicReference<>();
+		AtomicReference<Exception> errorRef = new AtomicReference<>();
+
+		Thread worker = new Thread(
+				() -> {
+					try {
+						resultRef.set(evaluate(theScript, theInputJson));
+					} catch (Exception e) {
+						errorRef.set(e);
+					}
+				},
+				"js-exec-" + Thread.currentThread().getId());
+		worker.setDaemon(true);
+		worker.start();
+
+		try {
+			worker.join(TimeUnit.SECONDS.toMillis(myTimeoutSeconds));
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			stopWorker(worker);
+			throw new InternalErrorException("Interrupted while waiting for script to complete.", e);
+		}
+
+		if (worker.isAlive()) {
+			stopWorker(worker);
+			throw new InvalidRequestException(
+					"JavaScript execution timed out after " + myTimeoutSeconds + " seconds.");
+		}
+
+		Exception error = errorRef.get();
+		if (error != null) {
+			// A ScriptException covers syntax/runtime JS errors; a RuntimeException covers e.g. the
+			// ClassFilter blocking a Java class access. Either way it is caller error -> 400, not 500.
+			ourLog.debug("JavaScript execution failed", error);
+			throw new InvalidRequestException("JavaScript execution failed: " + error.getMessage(), error);
+		}
+		return resultRef.get();
+	}
+
+	/** Evaluates the script in a fresh, sandboxed Nashorn engine and returns the JSON result. */
+	private String evaluate(String theScript, String theInputJson) throws ScriptException {
+		ScriptEngine engine = myEngineFactory.getScriptEngine(DENY_ALL_JAVA_CLASSES);
+		ScriptContext context = new SimpleScriptContext();
+		engine.setContext(context);
+		engine.put("__inputJson", theInputJson);
+
+		engine.eval("var input = JSON.parse(__inputJson);");
+		Object result = engine.eval(theScript);
+		engine.put("__result", result);
+		return (String) engine.eval("JSON.stringify(__result === undefined ? null : __result)");
+	}
+
+	/** Interrupts the worker, and forcibly stops it if it ignores interruption (e.g. a tight loop). */
+	@SuppressWarnings({"deprecation", "removal"})
+	private void stopWorker(Thread theWorker) {
+		theWorker.interrupt();
+		try {
+			theWorker.join(1000);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		if (theWorker.isAlive()) {
+			try {
+				// Nashorn does not interrupt CPU-bound loops; ThreadDeath is the only reliable stop.
+				theWorker.stop();
+			} catch (Throwable t) {
+				ourLog.warn("Unable to forcibly stop timed-out script thread", t);
+			}
+		}
+	}
+
+	/** Parses the script's JSON result (single object or array) back into FHIR resources. */
+	private List<Resource> parseOutputResources(String theResultJson) {
+		List<Resource> resources = new ArrayList<>();
+		if (theResultJson == null) {
+			return resources;
+		}
+
+		JsonNode root;
+		try {
+			root = myObjectMapper.readTree(theResultJson);
+		} catch (Exception e) {
+			throw new InvalidRequestException("Script result was not valid JSON: " + e.getMessage(), e);
+		}
+
+		if (root == null || root.isNull()) {
+			return resources;
+		}
+
+		IParser parser = myFhirContext.newJsonParser();
+		if (root.isArray()) {
+			for (JsonNode node : root) {
+				resources.add(parseResourceNode(parser, node));
+			}
+		} else {
+			resources.add(parseResourceNode(parser, root));
+		}
+		return resources;
+	}
+
+	private Resource parseResourceNode(IParser theParser, JsonNode theNode) {
+		if (!theNode.isObject() || !theNode.hasNonNull("resourceType")) {
+			throw new InvalidRequestException(
+					"Script must return FHIR resource object(s) with a 'resourceType'; got: " + theNode);
+		}
+		try {
+			return (Resource) theParser.parseResource(theNode.toString());
+		} catch (Exception e) {
+			throw new InvalidRequestException("Could not parse script result as a FHIR resource: " + e.getMessage(), e);
+		}
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
@@ -78,11 +78,11 @@ import java.util.regex.Pattern;
  * file name and the resolved path is verified to stay within that directory, so callers cannot
  * traverse the filesystem or execute code that the administrator has not installed. As
  * defense-in-depth, each script runs in a fresh GraalJS {@link Context} created with no host access
- * — Java class lookup, filesystem, network and thread creation are all denied by default — so
+ * — Java class lookup, filesystem, network, and thread creation are all denied by default — so
  * scripts are limited to pure JavaScript and cannot reach the host JVM, filesystem or network. Each
  * invocation is also bounded by an execution timeout
  * ({@code hapi.fhir.javascript_execution_timeout_seconds}, default 30s); a script that overruns has
- * its context cancelled and the call fails.
+ * its context canceled and the call fails.
  */
 @Conditional({OnR4Condition.class})
 @ConditionalOnProperty(name = "hapi.fhir.javascript_execution_enabled", havingValue = "true")
@@ -113,7 +113,7 @@ public class JavaScriptExecutionR4OperationProvider {
 		this.myTimeoutSeconds = theTimeoutSeconds;
 	}
 
-	@Operation(name = "$execute-javascript", idempotent = false)
+	@Operation(name = "$execute-javascript", idempotent = true)
 	public Parameters executeJavascript(
 			@OperationParam(name = "script", min = 1, max = 1) StringType theScriptName,
 			@OperationParam(name = "resource", min = 0, max = OperationParam.MAX_UNLIMITED)

--- a/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/javascript/JavaScriptExecutionR4OperationProvider.java
@@ -27,10 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Service;
 
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptException;
-import javax.script.SimpleScriptContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -41,6 +37,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import javax.script.SimpleScriptContext;
 
 /**
  * Custom R4 system-level operation that runs a server-side JavaScript file (via the standalone
@@ -253,8 +253,7 @@ public class JavaScriptExecutionR4OperationProvider {
 
 		if (worker.isAlive()) {
 			stopWorker(worker);
-			throw new InvalidRequestException(
-					"JavaScript execution timed out after " + myTimeoutSeconds + " seconds.");
+			throw new InvalidRequestException("JavaScript execution timed out after " + myTimeoutSeconds + " seconds.");
 		}
 
 		Exception error = errorRef.get();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -194,7 +194,7 @@ hapi:
     # -------------------------------------------------------------------------------
     ig_runtime_upload_enabled: false
     # Enables the R4 system-level $execute-javascript operation, which runs a server-side
-    # JavaScript file (sandboxed Nashorn) to transform FHIR resources. Callers reference a script
+    # JavaScript file (sandboxed GraalJS) to transform FHIR resources. Callers reference a script
     # by name; they cannot supply code. Disabled by default.
     javascript_execution_enabled: false
     # Directory holding the vetted *.js scripts the operation is allowed to run. The 'script'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -193,6 +193,16 @@ hapi:
     # B. Implementation Guides (IG) & Package Install
     # -------------------------------------------------------------------------------
     ig_runtime_upload_enabled: false
+    # Enables the R4 system-level $execute-javascript operation, which runs a server-side
+    # JavaScript file (sandboxed Nashorn) to transform FHIR resources. Callers reference a script
+    # by name; they cannot supply code. Disabled by default.
+    javascript_execution_enabled: false
+    # Directory holding the vetted *.js scripts the operation is allowed to run. The 'script'
+    # parameter is resolved to a file in this directory (name only, no paths). Required when
+    # javascript_execution_enabled is true.
+    # javascript_execution_scripts_dir: /etc/hapi/scripts
+    # Maximum wall-clock seconds a single script may run before it is stopped and the call fails.
+    # javascript_execution_timeout_seconds: 30
     # validate_resource_status_for_package_upload: false   # default true
     # install_transitive_ig_dependencies: true
     # implementationguides:

--- a/src/test/java/ca/uhn/fhir/jpa/starter/JavaScriptExecutionOperationTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/JavaScriptExecutionOperationTest.java
@@ -1,0 +1,244 @@
+package ca.uhn.fhir.jpa.starter;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Parameters;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		classes = {Application.class},
+		properties = {
+			"spring.datasource.url=jdbc:h2:mem:dbr4-js",
+			"spring.ai.mcp.server.enabled=false",
+			"hapi.fhir.cr_enabled=false",
+			"hapi.fhir.fhir_version=r4",
+			"hapi.fhir.javascript_execution_enabled=true",
+			// Scripts live under src/test/resources/javascript; reference it absolutely.
+			"hapi.fhir.javascript_execution_scripts_dir=${user.dir}/src/test/resources/javascript",
+			// Keep the timeout short so the infinite-loop test finishes quickly.
+			"hapi.fhir.javascript_execution_timeout_seconds=3"
+		})
+class JavaScriptExecutionOperationTest {
+
+	@LocalServerPort
+	private int port;
+
+	private IGenericClient client;
+	private FhirContext ctx;
+
+	@BeforeEach
+	void setUp() {
+		ctx = FhirContext.forR4();
+		ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+		ctx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
+		client = ctx.newRestfulGenericClient("http://localhost:" + port + "/fhir/");
+	}
+
+	private Parameters execute(String scriptName, org.hl7.fhir.r4.model.Resource... resources) {
+		Parameters in = new Parameters();
+		in.addParameter().setName("script").setValue(new StringType(scriptName));
+		for (org.hl7.fhir.r4.model.Resource resource : resources) {
+			in.addParameter().setName("resource").setResource(resource);
+		}
+		return client.operation()
+				.onServer()
+				.named("$execute-javascript")
+				.withParameters(in)
+				.execute();
+	}
+
+	private Patient patient(String family) {
+		Patient p = new Patient();
+		p.addName().setFamily(family);
+		return p;
+	}
+
+	@Test
+	void transformsBothInputResources() {
+		Patient a = patient("A");
+		a.setActive(false);
+		Patient b = patient("B");
+		b.setActive(false);
+
+		Parameters out = execute("set-active", a, b);
+
+		List<Parameters.ParametersParameterComponent> returns = out.getParameter();
+		assertEquals(2, returns.size());
+		assertEquals("return", returns.get(0).getName());
+		assertTrue(assertInstanceOf(Patient.class, returns.get(0).getResource()).getActive());
+		assertTrue(assertInstanceOf(Patient.class, returns.get(1).getResource()).getActive());
+	}
+
+	@Test
+	void mergesTwoResourcesIntoOne() {
+		// A script can read both inputs (input[0], input[1]) and emit a single combined resource.
+		Patient first = patient("First");
+		Patient second = patient("Second");
+
+		Parameters out = execute("merge", first, second);
+
+		assertEquals(1, out.getParameter().size());
+		Patient merged = (Patient) out.getParameter().get(0).getResource();
+		assertEquals("First", merged.getName().get(0).getFamily());
+		assertEquals("Second", merged.getName().get(1).getFamily());
+	}
+
+	@Test
+	void acceptsASingleObjectResult() {
+		Parameters out = execute("set-gender", patient("A"), patient("B"));
+
+		assertEquals(1, out.getParameter().size());
+		Patient result = (Patient) out.getParameter().get(0).getResource();
+		assertEquals(Enumerations.AdministrativeGender.FEMALE, result.getGender());
+	}
+
+	@Test
+	void acceptsScriptNameWithJsSuffix() {
+		Parameters out = execute("set-gender.js", patient("A"), patient("B"));
+		assertEquals(1, out.getParameter().size());
+	}
+
+	@Test
+	void canSynthesizeANewResource() {
+		Parameters out = execute("synthesize", patient("A"), patient("B"));
+
+		assertEquals(1, out.getParameter().size());
+		Observation obs = assertInstanceOf(Observation.class, out.getParameter().get(0).getResource());
+		assertEquals(Observation.ObservationStatus.FINAL, obs.getStatus());
+	}
+
+	@Test
+	void emptyResultProducesEmptyParameters() {
+		Parameters out = execute("empty", patient("A"), patient("B"));
+		assertTrue(out.getParameter().isEmpty());
+	}
+
+	@Test
+	void resolvesLiteralReferencesBeforeExecution() {
+		// Store a resource on the server, then reference it (rather than inlining it).
+		Patient stored = patient("Stored");
+		stored.setActive(false);
+		IIdType id = client.create().resource(stored).execute().getId().toUnqualifiedVersionless();
+
+		Parameters in = new Parameters();
+		in.addParameter().setName("script").setValue(new StringType("set-active"));
+		in.addParameter().setName("reference").setValue(new Reference(id.getValue()));
+
+		Parameters out = client.operation()
+				.onServer()
+				.named("$execute-javascript")
+				.withParameters(in)
+				.execute();
+
+		assertEquals(1, out.getParameter().size());
+		Patient result = (Patient) out.getParameter().get(0).getResource();
+		assertEquals("Stored", result.getNameFirstRep().getFamily());
+		assertTrue(result.getActive());
+	}
+
+	@Test
+	void mixesInlineResourcesAndReferences() {
+		Patient stored = patient("FromServer");
+		IIdType id = client.create().resource(stored).execute().getId().toUnqualifiedVersionless();
+
+		Parameters in = new Parameters();
+		in.addParameter().setName("script").setValue(new StringType("merge")); // uses input[0] + input[1]
+		in.addParameter().setName("resource").setResource(patient("Inline")); // input[0]
+		in.addParameter().setName("reference").setValue(new Reference(id.getValue())); // input[1]
+
+		Parameters out = client.operation()
+				.onServer()
+				.named("$execute-javascript")
+				.withParameters(in)
+				.execute();
+
+		assertEquals(1, out.getParameter().size());
+		Patient merged = (Patient) out.getParameter().get(0).getResource();
+		assertEquals("Inline", merged.getName().get(0).getFamily());
+		assertEquals("FromServer", merged.getName().get(1).getFamily());
+	}
+
+	@Test
+	void unresolvableReferenceIsRejected() {
+		Parameters in = new Parameters();
+		in.addParameter().setName("script").setValue(new StringType("set-active"));
+		in.addParameter().setName("reference").setValue(new Reference("Patient/does-not-exist"));
+
+		assertThrows(
+				ResourceNotFoundException.class,
+				() -> client.operation()
+						.onServer()
+						.named("$execute-javascript")
+						.withParameters(in)
+						.execute());
+	}
+
+	@Test
+	void acceptsZeroResources() {
+		// 'input' is simply an empty array; a script can ignore it and synthesize output.
+		Parameters out = execute("synthesize");
+		assertEquals(1, out.getParameter().size());
+		assertInstanceOf(Observation.class, out.getParameter().get(0).getResource());
+	}
+
+	@Test
+	void scriptErrorIsReportedAsBadRequest() {
+		assertThrows(InvalidRequestException.class, () -> execute("error", patient("A"), patient("B")));
+	}
+
+	@Test
+	void nonResourceResultIsRejected() {
+		assertThrows(InvalidRequestException.class, () -> execute("non-resource", patient("A"), patient("B")));
+	}
+
+	@Test
+	void longRunningScriptIsStoppedByTimeout() {
+		// The 3s timeout configured above must fire and abort the infinite loop.
+		long start = System.nanoTime();
+		assertThrows(InvalidRequestException.class, () -> execute("infinite-loop", patient("A"), patient("B")));
+		long elapsedSeconds = (System.nanoTime() - start) / 1_000_000_000L;
+		// Should fail soon after the 3s budget, not hang indefinitely.
+		assertTrue(elapsedSeconds < 20, "Execution was not stopped promptly; took " + elapsedSeconds + "s");
+	}
+
+	@Test
+	void unknownScriptIsRejected() {
+		assertThrows(InvalidRequestException.class, () -> execute("does-not-exist", patient("A"), patient("B")));
+	}
+
+	@Test
+	void pathTraversalIsRejected() {
+		assertThrows(
+				InvalidRequestException.class,
+				() -> execute("../application", patient("A"), patient("B")));
+	}
+
+	@Test
+	void javaAccessIsBlockedBySandbox() {
+		// The ClassFilter denies all Java classes, so Java.type(...) must fail rather than
+		// giving the script a handle on the host JVM.
+		assertThrows(InvalidRequestException.class, () -> execute("java-access", patient("A"), patient("B")));
+	}
+}

--- a/src/test/resources/javascript/empty.js
+++ b/src/test/resources/javascript/empty.js
@@ -1,0 +1,2 @@
+// Returns no resources.
+[];

--- a/src/test/resources/javascript/error.js
+++ b/src/test/resources/javascript/error.js
@@ -1,0 +1,2 @@
+// Throws to exercise the error path.
+throw 'boom';

--- a/src/test/resources/javascript/infinite-loop.js
+++ b/src/test/resources/javascript/infinite-loop.js
@@ -1,0 +1,4 @@
+// Never terminates — exercises the execution timeout / forced stop.
+while (true) {
+	// busy loop
+}

--- a/src/test/resources/javascript/java-access.js
+++ b/src/test/resources/javascript/java-access.js
@@ -1,3 +1,3 @@
-// Attempts to reach a Java class; must be blocked by the Nashorn ClassFilter.
+// Attempts to reach a Java class; must be blocked by the GraalJS sandbox ('Java' is undefined).
 Java.type('java.lang.Runtime');
 [];

--- a/src/test/resources/javascript/java-access.js
+++ b/src/test/resources/javascript/java-access.js
@@ -1,0 +1,3 @@
+// Attempts to reach a Java class; must be blocked by the Nashorn ClassFilter.
+Java.type('java.lang.Runtime');
+[];

--- a/src/test/resources/javascript/merge.js
+++ b/src/test/resources/javascript/merge.js
@@ -1,0 +1,3 @@
+// Merges the two input resources into a single resource (input[1]'s names appended to input[0]).
+input[0].name = input[0].name.concat(input[1].name);
+[input[0]];

--- a/src/test/resources/javascript/non-resource.js
+++ b/src/test/resources/javascript/non-resource.js
@@ -1,0 +1,2 @@
+// Returns an object that is not a FHIR resource (no resourceType).
+[{ foo: 'bar' }];

--- a/src/test/resources/javascript/set-active.js
+++ b/src/test/resources/javascript/set-active.js
@@ -1,0 +1,5 @@
+// Sets active=true on both input resources and returns them.
+input.map(function (p) {
+	p.active = true;
+	return p;
+});

--- a/src/test/resources/javascript/set-gender.js
+++ b/src/test/resources/javascript/set-gender.js
@@ -1,0 +1,3 @@
+// Returns a single resource (input[0]) with gender set.
+input[0].gender = 'female';
+input[0];

--- a/src/test/resources/javascript/synthesize.js
+++ b/src/test/resources/javascript/synthesize.js
@@ -1,0 +1,2 @@
+// Ignores the inputs and synthesizes a brand-new resource.
+[{ resourceType: 'Observation', status: 'final' }];


### PR DESCRIPTION
This pull request introduces a new feature that enables secure, server-side execution of administrator-vetted JavaScript scripts for transforming FHIR resources via the new R4 `$execute-javascript` operation. This is implemented using the GraalJS engine, is disabled by default, and includes comprehensive security measures such as sandboxing, strict script selection, and execution timeouts. The PR also adds configuration options and updates documentation and dependencies accordingly.

**New Feature: Server-side JavaScript Execution for FHIR Resources**

- **Implementation of `$execute-javascript` Operation:**
  - Adds `JavaScriptExecutionR4OperationProvider`, a new R4 system-level operation provider that executes administrator-installed JavaScript scripts (not user-supplied code) to transform FHIR resources.
  - Scripts are securely sandboxed (no host, filesystem, or network access) and run with a configurable timeout. Inputs can be inline resources or server-resolved references, and outputs are returned as FHIR resources.

- **Security and Configuration:**
  - Introduces new configuration options in `application.yaml` to enable the feature, specify the scripts directory, and set execution timeouts. The feature is disabled by default and requires explicit configuration to activate.
  - Ensures script names are strictly validated and only files in the configured directory can be executed, preventing path traversal.

**Integration and Dependency Updates**

- **Integration with Server Startup:**
  - Registers the new operation provider in the server configuration, ensuring it is only active when enabled. [[1]](diffhunk://#diff-afcacdb6ba648cc2a2347bd471753b3e4491a011b442f1080961a794542559adR55) [[2]](diffhunk://#diff-afcacdb6ba648cc2a2347bd471753b3e4491a011b442f1080961a794542559adR362) [[3]](diffhunk://#diff-afcacdb6ba648cc2a2347bd471753b3e4491a011b442f1080961a794542559adR428-R429)

- **Dependency Addition:**
  - Adds the GraalJS JavaScript engine dependency (`org.graalvm.js:js`) to the `pom.xml` to enable script execution on stock JDKs.

**Documentation**

- **README Update:**
  - Documents the `$execute-javascript` operation, its security model, configuration, usage examples, and a quickstart for Docker-based testing.