### PR TITLE
feat: add support for cross-partition subscriptions in configuration

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -1166,6 +1166,7 @@ public class AppProperties {
 		private Email email = null;
 		private Integer polling_interval_ms = null;
 		private Boolean immediately_queued = false;
+		private Boolean cross_partition_enabled = false;
 
 		public Boolean getResthook_enabled() {
 			return resthook_enabled;
@@ -1205,6 +1206,14 @@ public class AppProperties {
 
 		public void setImmediately_queued(Boolean immediately_queued) {
 			this.immediately_queued = immediately_queued;
+		}
+
+		public Boolean getCross_partition_enabled() {
+			return cross_partition_enabled;
+		}
+
+		public void setCross_partition_enabled(Boolean cross_partition_enabled) {
+			this.cross_partition_enabled = cross_partition_enabled;
 		}
 
 		public static class Email {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -1213,7 +1213,7 @@ public class AppProperties {
 		}
 
 		public void setCross_partition_enabled(Boolean cross_partition_enabled) {
-			this.cross_partition_enabled = cross_partition_enabled;
+			this.cross_partition_enabled = Boolean.TRUE.equals(cross_partition_enabled);
 		}
 
 		public static class Email {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -150,11 +150,11 @@ public class FhirServerConfigCommon {
 				subscriptionSettings.setSubscriptionChangeQueuedImmediately(
 						appProperties.getSubscription().getImmediately_queued());
 			}
-			if (appProperties.getSubscription().getCross_partition_enabled()) {
+			boolean crossPartitionEnabled = Boolean.TRUE.equals(appProperties.getSubscription().getCross_partition_enabled());
+			if (crossPartitionEnabled) {
 				ourLog.info("Enabling cross-partition subscriptions");
 			}
-			subscriptionSettings.setCrossPartitionSubscriptionEnabled(
-					appProperties.getSubscription().getCross_partition_enabled());
+			subscriptionSettings.setCrossPartitionSubscriptionEnabled(crossPartitionEnabled);
 		}
 		if (appProperties.getMdm_enabled()) {
 			// MDM requires the subscription of type message

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -150,6 +150,11 @@ public class FhirServerConfigCommon {
 				subscriptionSettings.setSubscriptionChangeQueuedImmediately(
 						appProperties.getSubscription().getImmediately_queued());
 			}
+			if (appProperties.getSubscription().getCross_partition_enabled()) {
+				ourLog.info("Enabling cross-partition subscriptions");
+			}
+			subscriptionSettings.setCrossPartitionSubscriptionEnabled(
+					appProperties.getSubscription().getCross_partition_enabled());
 		}
 		if (appProperties.getMdm_enabled()) {
 			// MDM requires the subscription of type message

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommon.java
@@ -150,7 +150,8 @@ public class FhirServerConfigCommon {
 				subscriptionSettings.setSubscriptionChangeQueuedImmediately(
 						appProperties.getSubscription().getImmediately_queued());
 			}
-			boolean crossPartitionEnabled = Boolean.TRUE.equals(appProperties.getSubscription().getCross_partition_enabled());
+			boolean crossPartitionEnabled =
+					Boolean.TRUE.equals(appProperties.getSubscription().getCross_partition_enabled());
 			if (crossPartitionEnabled) {
 				ourLog.info("Enabling cross-partition subscriptions");
 			}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -480,6 +480,11 @@ hapi:
     #   websocket_enabled: false
     #   polling_interval_ms: 5000
     #   immediately_queued: false
+    #   # Enables subscriptions created in the DEFAULT partition and marked with the
+    #   # cross-partition extension to match resources from all partitions.
+    #   # Requires the Subscription resource to include:
+    #   # https://smilecdr.com/fhir/ns/StructureDefinition/subscription-cross-partition
+    #   cross_partition_enabled: false
     #   email:
     #     from: some@test.com
     #     host: google.com

--- a/src/test/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommonSubscriptionSettingsTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigCommonSubscriptionSettingsTest.java
@@ -1,0 +1,49 @@
+package ca.uhn.fhir.jpa.starter.common;
+
+import ca.uhn.fhir.jpa.model.config.SubscriptionSettings;
+import ca.uhn.fhir.jpa.starter.AppProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FhirServerConfigCommonSubscriptionSettingsTest {
+
+	private final FhirServerConfigCommon myConfig = new FhirServerConfigCommon(new AppProperties());
+
+	@Test
+	void subscriptionSettingsDefaultToCrossPartitionDisabled() {
+		SubscriptionSettings settings = myConfig.subscriptionSettings(new AppProperties());
+
+		assertThat(settings.isCrossPartitionSubscriptionEnabled()).isFalse();
+	}
+
+	@Test
+	void subscriptionSettingsEnableCrossPartitionFromProperties() {
+		AppProperties appProperties = bindAppProperties(Map.of(
+				"hapi.fhir.subscription.cross_partition_enabled", "true"));
+
+		SubscriptionSettings settings = myConfig.subscriptionSettings(appProperties);
+
+		assertThat(settings.isCrossPartitionSubscriptionEnabled()).isTrue();
+	}
+
+	@Test
+	void subscriptionSettingsKeepCrossPartitionDisabledWhenPropertyIsFalse() {
+		AppProperties appProperties = bindAppProperties(Map.of(
+				"hapi.fhir.subscription.cross_partition_enabled", "false"));
+
+		SubscriptionSettings settings = myConfig.subscriptionSettings(appProperties);
+
+		assertThat(settings.isCrossPartitionSubscriptionEnabled()).isFalse();
+	}
+
+	private AppProperties bindAppProperties(Map<String, String> properties) {
+		return new Binder(new MapConfigurationPropertySource(properties))
+				.bind("hapi.fhir", AppProperties.class)
+				.get();
+	}
+}


### PR DESCRIPTION
This pull request adds support for configuring cross-partition subscriptions via application properties. The main changes introduce a new property to enable or disable cross-partition subscriptions, update configuration logic to respect this property, and add tests to ensure correct behavior.

**Configuration property and logic changes:**

* Added a new `cross_partition_enabled` property to the `Subscription` section of `AppProperties`, with appropriate getter and setter methods. [[1]](diffhunk://#diff-79251bbeac3bb7f417a707bbda464fdfb2394f40bd88e43a9f5472e0ed351c83R1169) [[2]](diffhunk://#diff-79251bbeac3bb7f417a707bbda464fdfb2394f40bd88e43a9f5472e0ed351c83R1211-R1218)
* Updated `FhirServerConfigCommon` to read the new property and set `SubscriptionSettings.setCrossPartitionSubscriptionEnabled` accordingly, including logging when enabled.
* Updated `application.yaml` comments to document the new `cross_partition_enabled` property and its usage.

**Testing:**

* Added a new test class `FhirServerConfigCommonSubscriptionSettingsTest` to verify that the cross-partition subscription setting is correctly enabled or disabled based on the property value.