### PR TITLE
Prepare Release 8.10.0-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <hapi.fhir.jpa.server.starter.revision>1</hapi.fhir.jpa.server.starter.revision>
+        <hapi.fhir.jpa.server.starter.revision>2</hapi.fhir.jpa.server.starter.revision>
         <clinical-reasoning.version>4.5.1</clinical-reasoning.version>
 
         <!-- Plugins Versions -->

--- a/src/test/java/ca/uhn/fhir/jpa/starter/CdsHooksServletIT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/CdsHooksServletIT.java
@@ -118,7 +118,7 @@ class CdsHooksServletIT implements IServerSupport {
 	@Test
 	void testCdsHooks() throws IOException {
 		loadBundle("r4/HelloWorld-Bundle.json", ourCtx, ourClient);
-		await().atMost(10000, TimeUnit.MILLISECONDS).until(this::hasCdsServices);
+		await().pollInterval(500, TimeUnit.MILLISECONDS).atMost(30, TimeUnit.SECONDS).until(this::hasCdsServices);
 		var cdsRequest = """
 			{
 			  "hookInstance": "12345",
@@ -157,7 +157,7 @@ class CdsHooksServletIT implements IServerSupport {
 	@Test
 	void testRec10() throws IOException {
 		loadBundle("r4/opioidcds-10-order-sign-bundle.json", ourCtx, ourClient);
-		await().atMost(20000, TimeUnit.MILLISECONDS).until(this::hasCdsServices);
+		await().pollInterval(500, TimeUnit.MILLISECONDS).atMost(30, TimeUnit.SECONDS).until(this::hasCdsServices);
 		var fhirServer = "  \"fhirServer\": " + "\"" + ourServerBase + "\"" + ",\n";
 		var cdsRequest = """
 			{


### PR DESCRIPTION
This pull request updates the HAPI FHIR JPA Server Starter dependency version and improves the reliability of asynchronous test assertions in the `CdsHooksServletIT` integration tests by adjusting polling intervals and timeouts.

Dependency updates:

* Updated `<hapi.fhir.jpa.server.starter.revision>` from `1` to `2` in `pom.xml` to use a newer version of the HAPI FHIR JPA Server Starter dependency.

Test reliability improvements:

* Changed the `await()` configuration in both `testCdsHooks` and `testRec10` methods in `CdsHooksServletIT.java` to use a 500ms polling interval and a maximum wait time of 30 seconds, making the tests more robust and less likely to fail due to timing issues. [[1]](diffhunk://#diff-7eeed911a45dcb3d86a61094a27459275cb41bbcd64a7bc78b6f451be9061793L121-R121) [[2]](diffhunk://#diff-7eeed911a45dcb3d86a61094a27459275cb41bbcd64a7bc78b6f451be9061793L160-R160)