### PR TITLE
add SubscriptionTopicConfig to FhirServerConfigR4

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigR4.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/FhirServerConfigR4.java
@@ -4,11 +4,18 @@ import ca.uhn.fhir.jpa.config.r4.JpaR4Config;
 import ca.uhn.fhir.jpa.starter.annotations.OnR4Condition;
 import ca.uhn.fhir.jpa.starter.cr.StarterCrR4Config;
 import ca.uhn.fhir.jpa.starter.ips.StarterIpsConfig;
+import ca.uhn.fhir.jpa.topic.SubscriptionTopicConfig;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
 @Conditional(OnR4Condition.class)
-@Import({JpaR4Config.class, StarterJpaConfig.class, StarterCrR4Config.class, StarterIpsConfig.class})
+@Import({
+	JpaR4Config.class,
+	SubscriptionTopicConfig.class,
+	StarterJpaConfig.class,
+	StarterCrR4Config.class,
+	StarterIpsConfig.class
+})
 public class FhirServerConfigR4 {}


### PR DESCRIPTION
Fixes #964

Add `SubscriptionTopicConfig` to the `@Import` list in `FhirServerConfigR4.java`.

`FhirServerConfigR4B` and `FhirServerConfigR5` both import `ca.uhn.fhir.jpa.topic.SubscriptionTopicConfig`, but `FhirServerConfigR4` did not. This caused `SubscriptionTopicMatchingListener` and the topic loader to never be registered for R4, so Backport-IG topic-based subscriptions were silently accepted and activated but never matched or delivered.