### PR TITLE
Fix Elasticsearch node-sniffing errors on the elastic profile

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/elastic/ElasticsearchConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/elastic/ElasticsearchConfig.java
@@ -9,6 +9,9 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.sniff.Sniffer;
+import org.elasticsearch.client.sniff.SnifferBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -33,6 +36,12 @@ import java.util.List;
  * <p>Because that autoconfiguration also provides the {@link ElasticsearchProperties} bean
  * via {@code @EnableConfigurationProperties}, we re-declare it here so this config keeps
  * working while the autoconfiguration stays excluded (see application-elastic.yaml).
+ *
+ * <p>Node sniffing is therefore off by default. If it is actually wanted it can be turned on
+ * explicitly via {@code spring.elasticsearch.restclient.sniffer.enabled=true} (see
+ * {@link #elasticsearchSniffer}). Note this only affects the {@link RestClient} used here
+ * (i.e. {@link ElasticsearchBootSvcImpl}); Hibernate Search uses its own client and is
+ * controlled separately via {@code hibernate.search.backend.discovery.enabled}.
  */
 @Configuration
 @Conditional(ElasticConfigCondition.class)
@@ -78,5 +87,27 @@ public class ElasticsearchConfig {
 	public ElasticsearchClient elasticsearchClient(RestClient restClient) {
 		RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
 		return new ElasticsearchClient(transport);
+	}
+
+	/**
+	 * Optional Elasticsearch node sniffer, disabled by default. Enable with
+	 * {@code spring.elasticsearch.restclient.sniffer.enabled=true}; the interval and
+	 * delay-after-failure reuse the standard {@code spring.elasticsearch.restclient.sniffer.*}
+	 * properties. Registered as a bean so it is closed on context shutdown.
+	 */
+	@Bean(destroyMethod = "close")
+	@ConditionalOnProperty(prefix = "spring.elasticsearch.restclient.sniffer", name = "enabled", havingValue = "true")
+	public Sniffer elasticsearchSniffer(RestClient restClient, ElasticsearchProperties properties) {
+		ElasticsearchProperties.Restclient.Sniffer sniffer =
+				properties.getRestclient().getSniffer();
+		SnifferBuilder builder = Sniffer.builder(restClient);
+		if (sniffer.getInterval() != null) {
+			builder.setSniffIntervalMillis((int) sniffer.getInterval().toMillis());
+		}
+		if (sniffer.getDelayAfterFailure() != null) {
+			builder.setSniffAfterFailureDelayMillis(
+					(int) sniffer.getDelayAfterFailure().toMillis());
+		}
+		return builder.build();
 	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/elastic/ElasticsearchConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/elastic/ElasticsearchConfig.java
@@ -10,6 +10,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -20,10 +21,22 @@ import java.util.List;
 /**
  * Custom Elasticsearch configuration that creates the ElasticsearchClient bean
  * without the sniffer. This is used when the default Spring Boot autoconfiguration
- * is excluded.
+ * ({@code ElasticsearchRestClientAutoConfiguration}) is excluded.
+ *
+ * <p>That autoconfiguration is what enables Elasticsearch node sniffing: in Spring Boot 3
+ * its {@code RestClientSnifferConfiguration} unconditionally registers a {@code Sniffer}
+ * bean whenever the {@code elasticsearch-rest-client-sniffer} JAR is on the classpath (it
+ * arrives transitively via hapi-fhir-jpaserver-base). The sniffer periodically queries
+ * {@code _nodes/http} and then tries to talk to the node publish addresses directly, which
+ * fails (repeated {@code ConnectException}) whenever ES sits behind a proxy/LB/k8s.
+ *
+ * <p>Because that autoconfiguration also provides the {@link ElasticsearchProperties} bean
+ * via {@code @EnableConfigurationProperties}, we re-declare it here so this config keeps
+ * working while the autoconfiguration stays excluded (see application-elastic.yaml).
  */
 @Configuration
 @Conditional(ElasticConfigCondition.class)
+@EnableConfigurationProperties(ElasticsearchProperties.class)
 public class ElasticsearchConfig {
 
 	@Bean

--- a/src/main/resources/application-elastic.yaml
+++ b/src/main/resources/application-elastic.yaml
@@ -4,9 +4,13 @@ spring:
     username: elastic
     password: elastic
 
-  autoconfigure:
-    # This empty exclude is needed to override the default exclusion of the Elasticsearch configuration.
-    exclude:
+  # NOTE: We intentionally do NOT override spring.autoconfigure.exclude here, so the base
+  # application.yaml exclusion of ElasticsearchRestClientAutoConfiguration stays in effect.
+  # That autoconfiguration would otherwise register a node-sniffing Sniffer bean (Spring Boot 3
+  # does so whenever elasticsearch-rest-client-sniffer is on the classpath), causing repeated
+  # "error while sniffing nodes" ConnectExceptions when ES is behind a proxy/LB. The custom
+  # ca.uhn.fhir.jpa.starter.elastic.ElasticsearchConfig provides the RestClient/ElasticsearchClient
+  # (without a sniffer) and the ElasticsearchProperties bean instead.
 
   jpa:
     properties:
@@ -29,6 +33,17 @@ spring:
               settings_file: ca/uhn/fhir/jpa/elastic/index-settings.json
               minimal_required_status_wait_timeout: 10000
               minimal_required_status: YELLOW
+
+            # Node discovery / sniffing for Hibernate Search's OWN Elasticsearch client.
+            # Default false. Only enable if HS should sniff cluster nodes; avoid behind a
+            # proxy/LB/k8s, where the sniffed node addresses are not reachable and you get
+            # repeated "error while sniffing nodes" ConnectExceptions.
+            # This is independent of the Spring-side sniffer used by the direct client in
+            # ca.uhn.fhir.jpa.starter.elastic.ElasticsearchConfig (enable that one via
+            # spring.elasticsearch.restclient.sniffer.enabled=true).
+            discovery:
+              enabled: false
+              # refresh_interval: 10  # seconds between sniffs when enabled
 
             dynamic_mapping: true
           indexing:


### PR DESCRIPTION
## Problem
On a stock JPA-starter + `elastic` profile, the server logs repeated errors every few minutes (no user config involved):

```
ERROR o.elasticsearch.client.sniff.Sniffer - error while sniffing nodes
java.net.ConnectException: Connection refused
```

The sniffer resolves node publish addresses and connects to them directly, which fails when ES is behind a proxy/LB/k8s.

## Root cause
Not Hibernate Search (its `discovery.enabled` defaults to `false`). It's Spring Boot's `ElasticsearchRestClientAutoConfiguration`, which in Spring Boot 3 registers a `Sniffer` bean as soon as `elasticsearch-rest-client-sniffer` is on the classpath (pulled in via `hapi-fhir-jpaserver-base`), with no property to disable it — see spring-projects/spring-boot#48155. In this starter it was triggered by the `elastic` profile's empty `spring.autoconfigure.exclude`, which re-enabled that auto-config — needed only to keep the `ElasticsearchProperties` bean.

> Excluding the sniffer jar in `pom.xml` doesn't work: it's a no-op on the starter (jar comes via `hapi-fhir-jpaserver-base`), and excluding it there breaks boot — Hibernate Search hard-references `NodesSniffer` → `NoClassDefFoundError`.

## Changes
- `ElasticsearchConfig`: add `@EnableConfigurationProperties(ElasticsearchProperties.class)` so it works while the auto-config stays excluded.
- `application-elastic.yaml`: drop the empty `spring.autoconfigure.exclude` override → base exclusion of `ElasticsearchRestClientAutoConfiguration` stays in effect → no auto-registered sniffer.
- Optional opt-in sniffer bean, **off by default**, via `spring.elasticsearch.restclient.sniffer.enabled=true`.
- Document the HS-side toggle `hibernate.search.backend.discovery.enabled` (default `false`) in `application-elastic.yaml`.

## Two independent sniffing surfaces
- Spring-side direct client (`ElasticsearchBootSvcImpl`) → `spring.elasticsearch.restclient.sniffer.enabled`
- Hibernate Search's own client (FHIR indexing/search) → `hibernate.search.backend.discovery.enabled`

## Testing (ES 8.15.3, `elastic` profile)
- Boots cleanly (no `NoClassDefFoundError`)
- Default: no sniffer thread, no sniffing errors
- `_content` full-text search returns hits via ES
- With the flag on: `es_rest_client_sniffer` thread starts (opt-in works)
- `mvn compile` green
