### PR TITLE
docs(docker): add compose environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+HAPI_FHIR_PORT=8080
+POSTGRES_DB=hapi
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=admin
+POSTGRES_HOST=hapi-fhir-postgres
+POSTGRES_PORT=5432
+HIBERNATE_DIALECT=ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.orig
 target/
 *.iml
+.env
 
 # Compiled class file
 *.class

--- a/README.md
+++ b/README.md
@@ -492,8 +492,9 @@ Docker compose is a simple option to build and deploy containers. To deploy with
 with `mvn clean install` and then bring up the containers with `docker-compose up -d --build`. The server can be
 reached at http://localhost:8080/.
 
-In order to use another port, change the `ports` parameter
-inside `docker-compose.yml` to `8888:8080`, where 8888 is a port of your choice.
+To customize the published port or PostgreSQL settings without editing `docker-compose.yml`, copy `.env.example` to
+`.env` and update the values before starting the containers. For example, set `HAPI_FHIR_PORT=8888` to reach the
+server at http://localhost:8888/.
 
 The docker compose set also includes PostgreSQL database, if you choose to use PostgreSQL instead of H2, change the following
 properties in `src/main/resources/application.yaml`:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
     container_name: hapi-fhir-jpaserver-start
     restart: on-failure
     environment:
-      SPRING_DATASOURCE_URL: "jdbc:postgresql://hapi-fhir-postgres:5432/hapi"
-      SPRING_DATASOURCE_USERNAME: "admin"
-      SPRING_DATASOURCE_PASSWORD: "admin"
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://${POSTGRES_HOST:-hapi-fhir-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-hapi}"
+      SPRING_DATASOURCE_USERNAME: "${POSTGRES_USER:-admin}"
+      SPRING_DATASOURCE_PASSWORD: "${POSTGRES_PASSWORD:-admin}"
       SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
-      HIBERNATE_DIALECT: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect
+      HIBERNATE_DIALECT: "${HIBERNATE_DIALECT:-ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect}"
     ports:
-      - "8080:8080"
+      - "${HAPI_FHIR_PORT:-8080}:8080"
     # Uncomment to enable periodic health checks.
     # Can also be run manually: docker exec hapi-fhir-jpaserver-start java -cp /app HealthCheck
     # healthcheck:
@@ -27,11 +27,11 @@ services:
     container_name: hapi-fhir-postgres
     restart: always
     environment:
-      POSTGRES_DB: "hapi"
-      POSTGRES_USER: "admin"
-      POSTGRES_PASSWORD: "admin"
+      POSTGRES_DB: "${POSTGRES_DB:-hapi}"
+      POSTGRES_USER: "${POSTGRES_USER:-admin}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-admin}"
     healthcheck:
-      test: ["CMD-SHELL", "sh -c 'pg_isready -U admin -d hapi' || exit 1"]
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER:-admin} -d ${POSTGRES_DB:-hapi}' || exit 1"]
       interval: 10s
       timeout: 5s
       start_period: 5s


### PR DESCRIPTION
## Summary
Add a small `.env.example` for Docker Compose users so they can customize the published port and PostgreSQL settings without editing `docker-compose.yml`.

## Changes
- Add `.env.example` with the current Docker Compose defaults.
- Read Docker Compose port and PostgreSQL values from environment variables with the same fallback defaults.
- Ignore local `.env` files and document the copy/edit workflow in the README.

## Testing
- Ran `git diff --check upstream/master...origin/docs/docker-compose-env-example`.
- Ran `docker compose config` with default values.
- Ran PowerShell override check with `HAPI_FHIR_PORT=8888` plus custom `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, and `POSTGRES_PORT`, then ran `docker compose config`.