### PR TITLE
docs(readme): align MCP endpoint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,4 +685,4 @@ You can configure the agent using environment variables or Java system propertie
 
 ## Enable MCP
 
-MCP capabilities can be enabled by setting the `spring.ai.mcp.server.enabled` to `true`. This will enable the MCP server and expose the MCP endpoints. The MCP endpoint is currently hardcoded to `/mcp/message` and can be tried out by running e.g. `npx @modelcontextprotocol/inspector` and connect to http://localhost:8080/mcp/message using Streamable HTTP. Spring AI MCP Server Auto Configuration is currently not supported.
+MCP capabilities can be enabled by setting the `spring.ai.mcp.server.enabled` to `true`. This will enable the MCP server and expose the MCP endpoints. The default MCP endpoint is `/mcp/messages` and can be tried out by running e.g. `npx @modelcontextprotocol/inspector` and connecting to http://localhost:8080/mcp/messages using Streamable HTTP. Spring AI MCP Server Auto Configuration is currently not supported.


### PR DESCRIPTION
﻿## Summary
- update the README MCP endpoint example to use `/mcp/messages`
- align the README with the default endpoint configured in `application.yaml` and `application-cds.yaml`

## Changes
- `README.md`: replace the singular `/mcp/message` example with `/mcp/messages` and clarify that it is the default endpoint.

## Validation
- git diff --check
- rg -n "/mcp/messages|mcp-endpoint" README.md src/main/resources/application.yaml src/main/resources/application-cds.yaml src/test/java/ca/uhn/fhir/jpa/starter/McpTests.java

## Notes
Documentation-only change. No runtime behavior changes.
