### PR TITLE
feat(helm-chart): add the option to add extra init containers

### DIFF
--- a/charts/hapi-fhir-jpaserver/Chart.yaml
+++ b/charts/hapi-fhir-jpaserver/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: oci://registry-1.docker.io/cloudpirates
     condition: postgres.enabled
 appVersion: 8.8.0
-version: 0.23.0
+version: 0.24.0
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/hapi-fhir-jpaserver/README.md
+++ b/charts/hapi-fhir-jpaserver/README.md
@@ -1,6 +1,6 @@
 # HAPI FHIR JPA Server Starter Helm Chart
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.8.0](https://img.shields.io/badge/AppVersion-8.8.0-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.8.0](https://img.shields.io/badge/AppVersion-8.8.0-informational?style=flat-square)
 
 This helm chart will help you install the HAPI FHIR JPA Server in a Kubernetes environment.
 
@@ -32,6 +32,7 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | externalDatabase.user | string | `"fhir"` | username for the external database |
 | extraConfig | string | `""` | additional Spring Boot application config. Mounted as a file and automatically loaded by the application. |
 | extraEnv | list | `[]` | extra environment variables to set on the server container |
+| extraInitContainers | list | `[]` | Optionally specify extra init containers |
 | extraVolumeMounts | list | `[]` | Optionally specify extra list of additional volumeMounts |
 | extraVolumes | list | `[]` | Optionally specify extra list of additional volumes |
 | fullnameOverride | string | `""` | override the chart fullname |
@@ -46,6 +47,7 @@ helm install hapi-fhir-jpaserver hapifhir/hapi-fhir-jpaserver
 | ingress.hosts[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.hosts[0].paths[0] | string | `"/"` |  |
 | ingress.tls | list | `[]` | ingress TLS config |
+| initContainers | object | `{"resources":{},"resourcesPreset":"nano"}` | Configures the default init container (which waits for the database to be ready) |
 | initContainers.resources | object | `{}` | configure the init containers pods resource requests and limits |
 | initContainers.resourcesPreset | string | `"nano"` | set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if `resources` is set (`resources` is recommended for production). |
 | metrics.service.port | int | `8081` |  |

--- a/charts/hapi-fhir-jpaserver/templates/deployment.yaml
+++ b/charts/hapi-fhir-jpaserver/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
                 echo "Waiting for DB ${PGUSER}@${PGHOST}:${PGPORT} to be up";
                 sleep 15;
               done;
+        {{- if .Values.extraInitContainers }}
+        {{- toYaml .Values.extraInitContainers | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/hapi-fhir-jpaserver/values.yaml
+++ b/charts/hapi-fhir-jpaserver/values.yaml
@@ -266,6 +266,7 @@ tests:
     seccompProfile:
       type: RuntimeDefault
 
+# -- Configures the default init container (which waits for the database to be ready)
 initContainers:
   # -- set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge).
   # This is ignored if `resources` is set (`resources` is recommended for production).
@@ -278,6 +279,9 @@ initContainers:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+# -- Optionally specify extra init containers
+extraInitContainers: []
 
 # -- additional Spring Boot application config. Mounted as a file and automatically loaded by the application.
 extraConfig:


### PR DESCRIPTION
The helm chart already gives the ability to add extraVolumes and extraVolumeMounts, which is handy

Sometimes, it is also handy to define other init containers: in my case, I would like to dynamically build a java key store when the container starts, avoiding having to bundle it with a container image

_Note: I can bundle this with #975 if we want to do a single helm chart release_