### PR TITLE
fix(consent): perbaiki interceptor consent yang belum pernah aktif + tambah cache invalidation

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,77 @@
+services:
+  hapi-fhir-jpaserver-start:
+    build: .
+    container_name: hapi-fhir-jpaserver-start
+    restart: on-failure
+    environment:
+      SPRING_DATASOURCE_URL: "jdbc:postgresql://hapi-fhir-postgres:5432/hapi"
+      SPRING_DATASOURCE_USERNAME: "admin"
+      SPRING_DATASOURCE_PASSWORD: "admin"
+      SPRING_DATASOURCE_DRIVER_CLASS_NAME: "org.postgresql.Driver"
+      HIBERNATE_DIALECT: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgresDialect
+      # URL registry Consent eksternal. Ini binding ke field ConsentProperties.urlConsentRegistry
+      # (prefix hapi.policy, flat field -> env var HAPI_POLICY_URL_CONSENT_REGISTRY).
+      # PENTING: kalau consent registry jalan di HOST machine (bukan container lain di
+      # compose ini), JANGAN pakai "localhost" - dari dalam container, localhost merujuk
+      # ke container itu sendiri, bukan ke host. Pakai host.docker.internal (lihat
+      # extra_hosts di bawah, wajib di Linux).
+      HAPI_POLICY_URL_CONSENT_REGISTRY: "http://host.docker.internal:4023/api/consent"
+      # Shared secret untuk endpoint invalidasi cache consent (/internal/consent-cache/invalidate).
+      # Consent registry (Go) harus kirim header X-Cache-Invalidation-Secret dengan value yang
+      # SAMA PERSIS ini setiap memanggil endpoint tsb. Ganti dengan value acak yang kuat sebelum
+      # dipakai di luar testing lokal.
+      HAPI_POLICY_CACHE_INVALIDATION_SECRET: "J9gTq8fNnr63gBoxtABTFjqZ"
+      # Default HAPI (ALPHANUMERIC) menolak client-assigned ID yang cuma angka murni
+      # (mis. PUT Organization/9900000000 -> HAPI-0960). Perlu ANY supaya seed data
+      # dengan ID numerik tetap (KEMENKES = 9900000000) bisa dibuat pakai PUT.
+      HAPI_FHIR_CLIENT_ID_STRATEGY: "ANY"
+    ports:
+      - "8080:8080"
+    # Uncomment untuk health check periodik.
+    # healthcheck:
+    #   test: ["CMD", "java", "-cp", "/app", "HealthCheck"]
+    #   interval: 30s
+    #   timeout: 10s
+    #   start_period: 60s
+    #   retries: 3
+    depends_on:
+      hapi-fhir-postgres:
+        condition: service_healthy
+      # Uncomment kalau service consent-registry sudah kamu tambahkan di file ini
+      # consent-registry:
+      #   condition: service_started
+    networks:
+      - satusehat-net
+    extra_hosts:
+      # Wajib di Linux supaya host.docker.internal bisa resolve ke host machine
+      # (di Docker Desktop Mac/Windows biasanya sudah otomatis tanpa ini).
+      - "host.docker.internal:host-gateway"
+
+  hapi-fhir-postgres:
+    image: postgres:16-alpine
+    container_name: hapi-fhir-postgres
+    environment:
+      POSTGRES_DB: "hapi"
+      POSTGRES_USER: "admin"
+      POSTGRES_PASSWORD: "admin"
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U admin -d hapi' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      start_period: 5s
+      retries: 5
+    volumes:
+      - ~/project/kamscode/docker-data/fhir-postgres/data:/var/lib/postgresql/data
+    networks:
+      - satusehat-net
+
+  adminer:
+      image: adminer
+      ports:
+        - "8081:8080"
+      networks:
+        - satusehat-net
+
+networks:
+  satusehat-net:
+    driver: bridge

--- a/k8s/hapi-headless-service.yaml
+++ b/k8s/hapi-headless-service.yaml
@@ -1,0 +1,34 @@
+# Headless Service - khusus untuk peer-discovery antar-pod, BUKAN untuk
+# traffic FHIR normal (traffic normal tetap lewat Service "hapi" ClusterIP
+# biasa yang sudah ada di manifest utama kamu).
+#
+# Kenapa ini dibutuhkan: endpoint /internal/consent-cache/invalidate di HAPI
+# menyimpan cache consent list in-memory PER-POD (per-JVM). Kalau
+# `replicas` di Deployment "hapi" nanti di-set > 1, Service ClusterIP biasa
+# cuma meneruskan request ke 1 pod (dipilih kube-proxy secara acak/round-robin)
+# - jadi pod lain tetap pakai cache basi walau sudah ada notifikasi invalidasi.
+#
+# Dengan Service headless (clusterIP: None), DNS lookup ke nama service ini
+# akan mengembalikan SEMUA IP pod yang match selector `app: hapi` - caller
+# (consent registry / webhook Go) bisa resolve semua IP lalu memanggil
+# endpoint invalidasi ke TIAP pod satu-satu, bukan cuma 1.
+#
+# Selama replicas: 1 (kondisi sekarang), Service ini tidak berpengaruh apa-apa
+# - baru relevan kalau nanti di-scale ke lebih dari 1 replica.
+apiVersion: v1
+kind: Service
+metadata:
+  name: hapi-headless
+  namespace: hapi-sandbox
+  labels:
+    app: hapi
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: hapi
+  ports:
+    - protocol: TCP
+      name: http
+      port: 8080
+      targetPort: 8080

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ActionEnum.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ActionEnum.java
@@ -1,0 +1,21 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+public enum ActionEnum {
+    READ,
+    CREATE,
+    UPDATE,
+    DELETE,
+    ACCESS;
+
+    public String getConsentAction() {
+        switch (this) {
+            case READ: return "read";
+            case CREATE: return "collect";
+            case UPDATE: return "disclose";
+            case DELETE: return "delete";
+            case ACCESS:
+            default:
+                return "access";
+        }
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AuditEventLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AuditEventLogger.java
@@ -1,0 +1,95 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import org.hl7.fhir.r4.model.AuditEvent;
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventAction;
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventAgentComponent;
+import org.hl7.fhir.r4.model.AuditEvent.AuditEventOutcome;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Reference;
+
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import ca.uhn.fhir.rest.server.interceptor.consent.IConsentContextServices;
+
+public class AuditEventLogger {
+    private IFhirResourceDao<AuditEvent> auditEventDao;
+    private String orgId;
+    private ConsentProperties consentProperties;
+
+    public AuditEventLogger(IFhirResourceDao<AuditEvent> auditEventDao, String orgId, ConsentProperties consentProperties) {
+        this.auditEventDao = auditEventDao;
+        this.orgId = orgId;
+        this.consentProperties = consentProperties;
+    }
+
+    public void createForFailedOperation(RequestDetails theRequestDetails, BaseServerResponseException theException,
+            IConsentContextServices theContextServices) {
+        AuditEvent auditEvent = new AuditEvent();
+            auditEvent.setAction(AuditEventAction.E); // Action: Execute (E)
+            auditEvent.setRecorded(new java.util.Date());
+
+            // Outcome: Minor Failure (4) atau Serious Failure (8)
+            auditEvent.setOutcome(AuditEventOutcome._4);
+
+            Coding eventType = new Coding();
+            eventType.setSystem("http://terminology.hl7.org/CodeSystem/audit-event-type");
+            eventType.setCode("rest");
+            eventType.setDisplay("RESTful Operation");
+            auditEvent.setType(eventType);
+
+            Coding eventSubType = new Coding();
+            eventSubType.setSystem("http://hl7.org/fhir/restful-interaction");
+            eventSubType.setCode(theRequestDetails.getRestOperationType() != null ? 
+                theRequestDetails.getRestOperationType().getCode() : "unknown");
+            eventSubType.setDisplay(theRequestDetails.getRestOperationType() != null ? 
+                theRequestDetails.getRestOperationType().name() : "Unknown");
+            auditEvent.addSubtype(eventSubType);
+
+            if (theException != null) {
+                auditEvent.setOutcomeDesc(theException.getMessage());
+            }
+
+            CodeableConcept purposeOfUse = new CodeableConcept();
+            Coding purposeCoding = new Coding();
+            purposeCoding.setSystem("http://terminology.hl7.org/CodeSystem/v3-ActReason");
+            purposeCoding.setCode("HREAT");
+            purposeCoding.setDisplay("healthcare treatment");
+            purposeOfUse.addCoding(purposeCoding);
+            auditEvent.addPurposeOfEvent(purposeOfUse);
+
+            if (orgId != null) {
+                AuditEventAgentComponent participant = new AuditEventAgentComponent();
+                participant.setWho(new Reference("Organization/" + orgId));
+                participant.setRequestor(true);
+                CodeableConcept participantRole = new CodeableConcept();
+                Coding roleCoding = new Coding();
+                roleCoding.setSystem("http://terminology.hl7.org/CodeSystem/v3-ParticipationType");
+                roleCoding.setCode("IRCP");
+                roleCoding.setDisplay("information recipient");
+                participantRole.addCoding(roleCoding);
+                participant.addRole(participantRole);
+                auditEvent.addAgent(participant);
+            }
+
+            AuditEventAgentComponent serverParticipant = new AuditEventAgentComponent();
+            serverParticipant.setWho(new Reference("Device/hapi-fhir-server"));
+            serverParticipant.setRequestor(false);
+            CodeableConcept serverRole = new CodeableConcept();
+            Coding serverRoleCoding = new Coding();
+            serverRoleCoding.setSystem("http://terminology.hl7.org/CodeSystem/v3-ParticipationType");
+            serverRoleCoding.setCode("AUT");
+            serverRoleCoding.setDisplay("author");
+            serverRole.addCoding(serverRoleCoding);
+            serverParticipant.addRole(serverRole);
+            auditEvent.addAgent(serverParticipant);
+
+            Coding securityLabel = new Coding();
+            securityLabel.setSystem(consentProperties.getOrganizationSecuritySystemName());
+            securityLabel.setCode(orgId != null ? orgId : "unknown");
+            auditEvent.getMeta().addSecurity(securityLabel);
+
+            auditEventDao.create(auditEvent, theRequestDetails);
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AuditEventLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/AuditEventLogger.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.r4.model.AuditEvent.AuditEventAgentComponent;
 import org.hl7.fhir.r4.model.AuditEvent.AuditEventOutcome;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Reference;
 
 import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
@@ -74,7 +75,17 @@ public class AuditEventLogger {
             }
 
             AuditEventAgentComponent serverParticipant = new AuditEventAgentComponent();
-            serverParticipant.setWho(new Reference("Device/hapi-fhir-server"));
+            // Pakai logical reference (identifier), bukan literal reference ("Device/<id>"),
+            // karena ID resource Device sekarang server-assigned (dibuat via POST, bukan PUT
+            // dengan id tetap) - jadi tidak ada ID literal yang bisa di-hardcode di sini.
+            // Logical reference juga tidak kena referential integrity check HAPI, jadi tetap
+            // jalan walau resource Device belum/tidak pernah dibuat sama sekali.
+            Reference serverDeviceRef = new Reference();
+            serverDeviceRef.setIdentifier(new Identifier()
+                    .setSystem("urn:ietf:rfc:3986")
+                    .setValue("hapi-fhir-server"));
+            serverDeviceRef.setDisplay("HAPI FHIR Server");
+            serverParticipant.setWho(serverDeviceRef);
             serverParticipant.setRequestor(false);
             CodeableConcept serverRole = new CodeableConcept();
             Coding serverRoleCoding = new Coding();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/CacheService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/CacheService.java
@@ -1,0 +1,189 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import ca.uhn.fhir.sl.cache.Cache;
+import ca.uhn.fhir.sl.cache.CacheFactory;
+
+public class CacheService {
+    private final EnumMap<CacheEnum, Cache<?, ?>> myCaches = new EnumMap<>(CacheEnum.class);
+
+    public CacheService() {
+        populateCaches();
+    }
+
+    private void populateCaches() {
+		for (CacheEnum next : CacheEnum.values()) {
+			Cache<Object, Object> nextCache;
+			switch (next) {
+                case CONSENT_LIST:
+					nextCache = CacheFactory.buildEternal(60, 250);
+					break;
+				case ENCOUNTER:
+				case SERVICE_REQUEST:
+				case EPISODE_OF_CARE:
+				default:
+					nextCache = CacheFactory.buildEternal(5, 5000);
+					break;
+            }
+
+			myCaches.put(next, nextCache);
+        }
+    }
+
+    public <K, T> T get(CacheEnum theCache, K theKey, Function<K, T> theSupplier) {
+		assert theCache.getKeyType().isAssignableFrom(theKey.getClass());
+		return doGet(theCache, theKey, theSupplier);
+	}
+
+	protected <K, T> T doGet(CacheEnum theCache, K theKey, Function<K, T> theSupplier) {
+		Cache<K, T> cache = getCache(theCache);
+		return cache.get(theKey, theSupplier);
+	}
+
+	/**
+	 * Fetch an item from the cache if it exists, and use the loading function to
+	 * obtain it otherwise.
+	 * <p>
+	 * This method will put the value into the cache using {@link #putAfterCommit(CacheEnum, Object, Object)}.
+	 */
+	public <K, T> T getThenPutAfterCommit(CacheEnum theCache, K theKey, Function<K, T> theSupplier) {
+		assert theCache.getKeyType().isAssignableFrom(theKey.getClass());
+		T retVal = getIfPresent(theCache, theKey);
+		if (retVal == null) {
+			retVal = theSupplier.apply(theKey);
+			putAfterCommit(theCache, theKey, retVal);
+		}
+		return retVal;
+	}
+
+	/**
+	 * Fetch an item from the cache if it exists and use the loading function to
+	 * obtain it otherwise. If the loading function returns null, the item will not
+	 * be placed in the cache and <code>null</code> will be returned.
+	 * <p>
+	 * This method will put the value into the cache using {@link #putAfterCommit(CacheEnum, Object, Object)}.
+	 *
+	 * @since 8.6.0
+	 */
+	public <K, T> T getThenPutAfterCommitIfNotNull(CacheEnum theCache, K theKey, Function<K, T> theSupplier) {
+		assert theCache.getKeyType().isAssignableFrom(theKey.getClass());
+		T retVal = getIfPresent(theCache, theKey);
+		if (retVal == null) {
+			retVal = theSupplier.apply(theKey);
+			if (retVal != null) {
+				putAfterCommit(theCache, theKey, retVal);
+			}
+		}
+		return retVal;
+	}
+
+	public <K, V> V getIfPresent(CacheEnum theCache, K theKey) {
+		assert theCache.getKeyType().isAssignableFrom(theKey.getClass());
+		return doGetIfPresent(theCache, theKey);
+	}
+
+	protected <K, V> V doGetIfPresent(CacheEnum theCache, K theKey) {
+		return (V) getCache(theCache).getIfPresent(theKey);
+	}
+
+	public <K, V> void put(CacheEnum theCache, K theKey, V theValue) {
+		assert theCache.getKeyType().isAssignableFrom(theKey.getClass())
+				: "Key type " + theKey.getClass() + " doesn't match expected " + theCache.getKeyType() + " for cache "
+						+ theCache;
+		doPut(theCache, theKey, theValue);
+	}
+
+	protected <K, V> void doPut(CacheEnum theCache, K theKey, V theValue) {
+		getCache(theCache).put(theKey, theValue);
+	}
+
+	/**
+	 * This method registers a transaction synchronization that puts an entry in the cache
+	 * if and when the current database transaction successfully commits. If the
+	 * transaction is rolled back, the key+value passed into this method will
+	 * not be added to the cache.
+	 * <p>
+	 * This is useful for situations where you want to store something that has been
+	 * resolved in the DB during the current transaction, but it's not yet guaranteed
+	 * that this item will successfully save to the DB. Use this method in that case
+	 * in order to avoid cache poisoning.
+	 */
+	public <K, V> void putAfterCommit(CacheEnum theCache, K theKey, V theValue) {
+		assert theCache.getKeyType().isAssignableFrom(theKey.getClass())
+				: "Key type " + theKey.getClass() + " doesn't match expected " + theCache.getKeyType() + " for cache "
+						+ theCache;
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					put(theCache, theKey, theValue);
+				}
+			});
+		} else {
+			put(theCache, theKey, theValue);
+		}
+	}
+
+	public <K, V> Map<K, V> getAllPresent(CacheEnum theCache, Collection<K> theKeys) {
+		return doGetAllPresent(theCache, theKeys);
+	}
+
+	protected <K, V> Map<K, V> doGetAllPresent(CacheEnum theCache, Collection<K> theKeys) {
+		return (Map<K, V>) getCache(theCache).getAllPresent(theKeys);
+	}
+
+	public void invalidateAllCaches() {
+		myCaches.values().forEach(Cache::invalidateAll);
+	}
+
+	private <K, T> Cache<K, T> getCache(CacheEnum theCache) {
+		return (Cache<K, T>) myCaches.get(theCache);
+	}
+
+	public long getEstimatedSize(CacheEnum theCache) {
+		return getCache(theCache).estimatedSize();
+	}
+
+	public void invalidateCaches(CacheEnum... theCaches) {
+		for (CacheEnum next : theCaches) {
+			getCache(next).invalidateAll();
+		}
+	}
+
+    public enum CacheEnum {
+        CONSENT_LIST(String.class),
+        ENCOUNTER(String.class),
+        SERVICE_REQUEST(String.class),
+        EPISODE_OF_CARE(String.class);
+
+        private final Class<?> myKeyType;
+
+		CacheEnum(Class<?> theKeyType) {
+			myKeyType = theKeyType;
+		}
+
+		public Class<?> getKeyType() {
+			return myKeyType;
+		}
+
+		public static CacheEnum fromResourceType(String resourceType) {
+			switch (resourceType) {
+				case "Encounter":
+					return ENCOUNTER;
+				case "ServiceRequest":
+					return SERVICE_REQUEST;
+				case "EpisodeOfCare":
+					return EPISODE_OF_CARE;
+			}
+
+			return null;
+		}
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/CacheService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/CacheService.java
@@ -19,15 +19,23 @@ public class CacheService {
     }
 
     private void populateCaches() {
-		for (CacheEnum next : CacheEnum.values()) {
-			Cache<Object, Object> nextCache;
-			switch (next) {
-                case CONSENT_LIST:
-					nextCache = CacheFactory.buildEternal(60, 250);
+    for (CacheEnum next : CacheEnum.values()) {
+    Cache<Object, Object> nextCache;
+    switch (next) {
+    case CONSENT_LIST:
+    // TTL diperpendek dari 60 -> 10 menit. Ini sekarang cuma jadi
+    // fallback safety-net, karena invalidasi normalnya sudah lewat
+     // endpoint /internal/consent-cache/invalidate (webhook dari
+     // consent registry setiap ada perubahan Consent/Provision).
+     // TTL ini menjaga batas atas staleness kalau webhook gagal
+     // terkirim (network blip, pod baru saja restart, dst) - terutama
+    // penting di deployment multi-replica di mana webhook cuma
+    // menjangkau satu pod per panggilan (lihat service-headless.yaml).
+    nextCache = CacheFactory.buildEternal(10, 250);
 					break;
-				case ENCOUNTER:
-				case SERVICE_REQUEST:
-				case EPISODE_OF_CARE:
+     case ENCOUNTER:
+    case SERVICE_REQUEST:
+    case EPISODE_OF_CARE:
 				default:
 					nextCache = CacheFactory.buildEternal(5, 5000);
 					break;
@@ -155,6 +163,17 @@ public class CacheService {
 		for (CacheEnum next : theCaches) {
 			getCache(next).invalidateAll();
 		}
+	}
+
+	/**
+	 * Invalidate satu entry spesifik di dalam sebuah cache, berdasarkan key-nya.
+	 * Dipakai untuk invalidasi selektif (mis. consent list utk satu organisasi
+	 * saja), tanpa perlu membuang seluruh isi cache lewat {@link #invalidateCaches}.
+	 */
+	public <K> void invalidate(CacheEnum theCache, K theKey) {
+		assert theCache.getKeyType().isAssignableFrom(theKey.getClass());
+		Cache<K, Object> cache = getCache(theCache);
+		cache.invalidate(theKey);
 	}
 
     public enum CacheEnum {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentCacheInvalidationController.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentCacheInvalidationController.java
@@ -1,0 +1,117 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Endpoint internal untuk invalidasi cache consent list per-organisasi.
+ * <p>
+ * Endpoint ini SENGAJA didaftarkan sebagai Spring {@code @RestController}
+ * biasa (bukan bagian dari FHIR {@code RestfulServer}), supaya:
+ * </p>
+ * <ul>
+ *   <li>Tidak melalui {@link ConsentEnforcementInterceptor} sama sekali
+ *       (tidak butuh header {@code X-Organization-ID}).</li>
+ *   <li>Path-nya terpisah dari base FHIR ({@code /fhir/*}), jadi tidak
+ *       bentrok dengan resource FHIR apapun.</li>
+ * </ul>
+ * <p>
+ * Dipanggil oleh consent registry (service Go terpisah) setiap ada
+ * perubahan (create/update/delete) pada resource {@code Consent} atau
+ * {@code Provision} di suatu organisasi, supaya cache 60 menit di
+ * {@link ResourceManipulationInterceptor} tidak menyajikan data basi.
+ * </p>
+ * <p>
+ * <b>Keamanan:</b> endpoint ini wajib menyertakan header
+ * {@code X-Cache-Invalidation-Secret} yang cocok dengan
+ * {@code hapi.policy.cache-invalidation-secret} (env var
+ * {@code HAPI_POLICY_CACHE_INVALIDATION_SECRET}). Kalau secret belum
+ * di-set di server (kosong), endpoint ini SELALU menolak request apapun
+ * (fail-closed) - bukan fail-open - supaya tidak ada orang bisa memicu
+ * cache-miss flood ke registry tanpa otentikasi.
+ * </p>
+ */
+@RestController
+@RequestMapping("/internal/consent-cache")
+public class ConsentCacheInvalidationController {
+
+    @Autowired
+    private ResourceManipulationInterceptor resourceManipulationInterceptor;
+
+    @Autowired
+    private ConsentProperties consentProperties;
+
+    public static class InvalidateRequest {
+        private String organizationId;
+
+        public String getOrganizationId() {
+            return organizationId;
+        }
+
+        public void setOrganizationId(String organizationId) {
+            this.organizationId = organizationId;
+        }
+    }
+
+    public static class InvalidateResponse {
+        private boolean success;
+        private String message;
+        private String organizationId;
+
+        public InvalidateResponse(boolean success, String message, String organizationId) {
+            this.success = success;
+            this.message = message;
+            this.organizationId = organizationId;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public String getOrganizationId() {
+            return organizationId;
+        }
+    }
+
+    @PostMapping("/invalidate")
+    public ResponseEntity<InvalidateResponse> invalidate(
+            @RequestHeader(value = "X-Cache-Invalidation-Secret", required = false) String secret,
+            @RequestBody InvalidateRequest body) {
+
+        String expectedSecret = consentProperties.getCacheInvalidationSecret();
+
+        // Fail-closed: kalau secret belum dikonfigurasi di server, tolak semua request.
+        if (expectedSecret == null || expectedSecret.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new InvalidateResponse(false,
+                            "Cache invalidation secret belum dikonfigurasi di server (hapi.policy.cache-invalidation-secret kosong).",
+                            null));
+        }
+
+        if (secret == null || !expectedSecret.equals(secret)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(new InvalidateResponse(false, "Invalid or missing X-Cache-Invalidation-Secret header.", null));
+        }
+
+        if (body == null || body.getOrganizationId() == null || body.getOrganizationId().isEmpty()) {
+            return ResponseEntity.badRequest()
+                    .body(new InvalidateResponse(false, "Field organizationId wajib diisi.", null));
+        }
+
+        resourceManipulationInterceptor.invalidateConsentCache(body.getOrganizationId());
+
+        return ResponseEntity.ok(new InvalidateResponse(true,
+                "Cache consent list untuk organisasi " + body.getOrganizationId() + " berhasil di-invalidate.",
+                body.getOrganizationId()));
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementInterceptor.java
@@ -1,0 +1,642 @@
+/*-
+ * #%L
+ * HAPI FHIR - Server Framework
+ * %%
+ * Copyright (C) 2014 - 2025 Smile CDR, Inc.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
+import ca.uhn.fhir.context.BaseRuntimeElementDefinition;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.i18n.Msg;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.server.IPreResourceAccessDetails;
+import ca.uhn.fhir.rest.api.server.IPreResourceShowDetails;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.ResponseDetails;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.api.server.bulk.BulkExportJobParameters;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationConstants;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOperationStatusEnum;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+import ca.uhn.fhir.rest.server.interceptor.consent.IConsentContextServices;
+import ca.uhn.fhir.rest.server.util.ICachedSearchDetails;
+import ca.uhn.fhir.util.BundleUtil;
+import ca.uhn.fhir.util.IModelVisitor2;
+import com.google.common.annotations.VisibleForTesting;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.apache.commons.lang3.Validate;
+import org.hl7.fhir.instance.model.api.IBase;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static ca.uhn.fhir.rest.api.Constants.URL_TOKEN_METADATA;
+import static ca.uhn.fhir.rest.server.provider.ProviderConstants.OPERATION_META;
+
+/**
+ * The ConsentInterceptor can be used to apply arbitrary consent rules and data access policies
+ * on responses from a FHIR server.
+ * <p>
+ * See <a href="https://hapifhir.io/hapi-fhir/docs/security/consent_interceptor.html">Consent Interceptor</a> for
+ * more information on this interceptor.
+ * </p>
+ */
+@Interceptor(order = AuthorizationConstants.ORDER_CONSENT_INTERCEPTOR)
+public class ConsentEnforcementInterceptor {
+	private static final AtomicInteger ourInstanceCount = new AtomicInteger(0);
+	private final int myInstanceIndex = ourInstanceCount.incrementAndGet();
+	private final String myRequestAuthorizedKey =
+			ConsentEnforcementInterceptor.class.getName() + "_" + myInstanceIndex + "_AUTHORIZED";
+	private final String myRequestCompletedKey =
+			ConsentEnforcementInterceptor.class.getName() + "_" + myInstanceIndex + "_COMPLETED";
+	private final String myRequestSeenResourcesKey =
+			ConsentEnforcementInterceptor.class.getName() + "_" + myInstanceIndex + "_SEENRESOURCES";
+
+	private volatile List<IConsentEnforcementService> myConsentService = Collections.emptyList();
+	private IConsentContextServices myContextConsentServices = IConsentContextServices.NULL_IMPL;
+
+	/**
+	 * Constructor
+	 */
+	public ConsentEnforcementInterceptor() {
+		super();
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param theConsentService Must not be <code>null</code>
+	 */
+	public ConsentEnforcementInterceptor(IConsentEnforcementService theConsentService) {
+		this(theConsentService, IConsentContextServices.NULL_IMPL);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param theConsentService         Must not be <code>null</code>
+	 * @param theContextConsentServices Must not be <code>null</code>
+	 */
+	public ConsentEnforcementInterceptor(IConsentEnforcementService theConsentService, IConsentContextServices theContextConsentServices) {
+		setConsentService(theConsentService);
+		setContextConsentServices(theContextConsentServices);
+	}
+
+	public void setContextConsentServices(IConsentContextServices theContextConsentServices) {
+		Validate.notNull(theContextConsentServices, "theContextConsentServices must not be null");
+		myContextConsentServices = theContextConsentServices;
+	}
+
+	/**
+	 * @deprecated Use {@link #registerConsentService(IConsentEnforcementService)} instead
+	 */
+	@Deprecated
+	public void setConsentService(IConsentEnforcementService theConsentService) {
+		Validate.notNull(theConsentService, "theConsentService must not be null");
+		myConsentService = Collections.singletonList(theConsentService);
+	}
+
+	/**
+	 * Adds a consent service to the chain.
+	 * <p>
+	 * Thread safety note: This method can be called while the service is actively processing requestes
+	 *
+	 * @param theConsentService The service to register. Must not be <code>null</code>.
+	 * @since 6.0.0
+	 */
+	public ConsentEnforcementInterceptor registerConsentService(IConsentEnforcementService theConsentService) {
+		Validate.notNull(theConsentService, "theConsentService must not be null");
+		List<IConsentEnforcementService> newList = new ArrayList<>(myConsentService.size() + 1);
+		newList.addAll(myConsentService);
+		newList.add(theConsentService);
+		myConsentService = newList;
+		return this;
+	}
+
+	/**
+	 * Removes a consent service from the chain.
+	 * <p>
+	 * Thread safety note: This method can be called while the service is actively processing requestes
+	 *
+	 * @param theConsentService The service to unregister. Must not be <code>null</code>.
+	 * @since 6.0.0
+	 */
+	public ConsentEnforcementInterceptor unregisterConsentService(IConsentEnforcementService theConsentService) {
+		Validate.notNull(theConsentService, "theConsentService must not be null");
+		List<IConsentEnforcementService> newList =
+				myConsentService.stream().filter(t -> t != theConsentService).collect(Collectors.toList());
+		myConsentService = newList;
+		return this;
+	}
+
+	@VisibleForTesting
+	public List<IConsentEnforcementService> getConsentServices() {
+		return Collections.unmodifiableList(myConsentService);
+	}
+
+	@Hook(value = Pointcut.SERVER_INCOMING_REQUEST_PRE_HANDLED)
+	public void interceptPreHandled(RequestDetails theRequestDetails) {
+		if (isSkipServiceForRequest(theRequestDetails)) {
+			return;
+		}
+
+		validateParameter(theRequestDetails.getParameters());
+
+		for (IConsentEnforcementService nextService : myConsentService) {
+			ConsentOutcome outcome = nextService.startOperation(theRequestDetails, myContextConsentServices);
+			Validate.notNull(outcome, "Consent service returned null outcome");
+
+			switch (outcome.getStatus()) {
+				case REJECT:
+					throw toForbiddenOperationException(outcome);
+				case PROCEED:
+					continue;
+				case AUTHORIZED:
+					authorizeRequest(theRequestDetails);
+					return;
+			}
+		}
+	}
+
+	protected void authorizeRequest(RequestDetails theRequestDetails) {
+		Map<Object, Object> userData = theRequestDetails.getUserData();
+		userData.put(myRequestAuthorizedKey, Boolean.TRUE);
+	}
+
+	/**
+	 * Check if this request is eligible for cached search results.
+	 * We can't use a cached result if consent may use canSeeResource.
+	 * This checks for AUTHORIZED requests, and the responses from shouldProcessCanSeeResource()
+	 * to see if this holds.
+	 * @return may the request be satisfied from cache.
+	 */
+	@Hook(value = Pointcut.STORAGE_PRECHECK_FOR_CACHED_SEARCH)
+	public boolean interceptPreCheckForCachedSearch(@Nonnull RequestDetails theRequestDetails) {
+		return !isProcessCanSeeResource(theRequestDetails, null);
+	}
+
+	/**
+	 * Check if the search results from this request might be reused by later searches.
+	 * We can't use a cached result if consent may use canSeeResource.
+	 * This checks for AUTHORIZED requests, and the responses from shouldProcessCanSeeResource()
+	 * to see if this holds.
+	 * If not, marks the result as single-use.
+	 */
+	@Hook(value = Pointcut.STORAGE_PRESEARCH_REGISTERED)
+	public void interceptPreSearchRegistered(
+			RequestDetails theRequestDetails, ICachedSearchDetails theCachedSearchDetails) {
+		if (isProcessCanSeeResource(theRequestDetails, null)) {
+			theCachedSearchDetails.setCannotBeReused();
+		}
+	}
+
+	@Hook(value = Pointcut.STORAGE_PREACCESS_RESOURCES)
+	public void interceptPreAccess(
+			RequestDetails theRequestDetails, IPreResourceAccessDetails thePreResourceAccessDetails) {
+
+		// Flags for each service
+		boolean[] processConsentSvcs = new boolean[myConsentService.size()];
+		boolean processAnyConsentSvcs = isProcessCanSeeResource(theRequestDetails, processConsentSvcs);
+
+		if (!processAnyConsentSvcs) {
+			return;
+		}
+
+		IdentityHashMap<IBaseResource, ConsentOperationStatusEnum> alreadySeenResources =
+				getAlreadySeenResourcesMap(theRequestDetails);
+		for (int resourceIdx = 0; resourceIdx < thePreResourceAccessDetails.size(); resourceIdx++) {
+			IBaseResource nextResource = thePreResourceAccessDetails.getResource(resourceIdx);
+			for (int consentSvcIdx = 0; consentSvcIdx < myConsentService.size(); consentSvcIdx++) {
+				IConsentEnforcementService nextService = myConsentService.get(consentSvcIdx);
+
+				if (!processConsentSvcs[consentSvcIdx]) {
+					continue;
+				}
+
+				ConsentOutcome outcome =
+						nextService.canSeeResource(theRequestDetails, nextResource, myContextConsentServices);
+				Validate.notNull(outcome, "Consent service returned null outcome");
+				Validate.isTrue(
+						outcome.getResource() == null,
+						"Consent service returned a resource in its outcome. This is not permitted in canSeeResource(..)");
+
+				boolean skipSubsequentServices = false;
+				switch (outcome.getStatus()) {
+					case PROCEED:
+						break;
+					case AUTHORIZED:
+						alreadySeenResources.put(nextResource, ConsentOperationStatusEnum.AUTHORIZED);
+						skipSubsequentServices = true;
+						break;
+					case REJECT:
+						alreadySeenResources.put(nextResource, ConsentOperationStatusEnum.REJECT);
+						thePreResourceAccessDetails.setDontReturnResourceAtIndex(resourceIdx);
+						skipSubsequentServices = true;
+						break;
+				}
+
+				if (skipSubsequentServices) {
+					break;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Is canSeeResource() active in any services?
+	 * @param theProcessConsentSvcsFlags filled in with the responses from shouldProcessCanSeeResource each service
+	 * @return true of any service responded true to shouldProcessCanSeeResource()
+	 */
+	private boolean isProcessCanSeeResource(
+			@Nonnull RequestDetails theRequestDetails, @Nullable boolean[] theProcessConsentSvcsFlags) {
+		if (isRequestAuthorized(theRequestDetails)) {
+			return false;
+		}
+		if (isSkipServiceForRequest(theRequestDetails)) {
+			return false;
+		}
+		if (myConsentService.isEmpty()) {
+			return false;
+		}
+
+		if (theProcessConsentSvcsFlags == null) {
+			theProcessConsentSvcsFlags = new boolean[myConsentService.size()];
+		}
+		Validate.isTrue(theProcessConsentSvcsFlags.length == myConsentService.size());
+		boolean processAnyConsentSvcs = false;
+		for (int consentSvcIdx = 0; consentSvcIdx < myConsentService.size(); consentSvcIdx++) {
+			IConsentEnforcementService nextService = myConsentService.get(consentSvcIdx);
+
+			boolean shouldCallCanSeeResource =
+					nextService.shouldProcessCanSeeResource(theRequestDetails, myContextConsentServices);
+			processAnyConsentSvcs |= shouldCallCanSeeResource;
+			theProcessConsentSvcsFlags[consentSvcIdx] = shouldCallCanSeeResource;
+		}
+		return processAnyConsentSvcs;
+	}
+
+	@Hook(value = Pointcut.STORAGE_PRESHOW_RESOURCES)
+	public void interceptPreShow(RequestDetails theRequestDetails, IPreResourceShowDetails thePreResourceShowDetails) {
+		if (isRequestAuthorized(theRequestDetails)) {
+			return;
+		}
+		if (isAllowListedRequest(theRequestDetails)) {
+			return;
+		}
+		if (isSkipServiceForRequest(theRequestDetails)) {
+			return;
+		}
+		if (myConsentService.isEmpty()) {
+			return;
+		}
+
+		IdentityHashMap<IBaseResource, ConsentOperationStatusEnum> alreadySeenResources =
+				getAlreadySeenResourcesMap(theRequestDetails);
+
+		for (int i = 0; i < thePreResourceShowDetails.size(); i++) {
+
+			IBaseResource resource = thePreResourceShowDetails.getResource(i);
+			if (resource == null
+					|| alreadySeenResources.putIfAbsent(resource, ConsentOperationStatusEnum.PROCEED) != null) {
+				continue;
+			}
+
+			for (IConsentEnforcementService nextService : myConsentService) {
+				ConsentOutcome nextOutcome =
+						nextService.willSeeResource(theRequestDetails, resource, myContextConsentServices);
+				IBaseResource newResource = nextOutcome.getResource();
+
+				switch (nextOutcome.getStatus()) {
+					case PROCEED:
+						if (newResource != null) {
+							thePreResourceShowDetails.setResource(i, newResource);
+							resource = newResource;
+						}
+						continue;
+					case AUTHORIZED:
+						alreadySeenResources.put(resource, ConsentOperationStatusEnum.AUTHORIZED);
+						if (newResource != null) {
+							thePreResourceShowDetails.setResource(i, newResource);
+						}
+						continue;
+					case REJECT:
+						alreadySeenResources.put(resource, ConsentOperationStatusEnum.REJECT);
+						if (nextOutcome.getOperationOutcome() != null) {
+							IBaseOperationOutcome newOperationOutcome = nextOutcome.getOperationOutcome();
+							thePreResourceShowDetails.setResource(i, newOperationOutcome);
+							alreadySeenResources.put(newOperationOutcome, ConsentOperationStatusEnum.PROCEED);
+						} else {
+							resource = null;
+							thePreResourceShowDetails.setResource(i, null);
+						}
+						continue;
+				}
+			}
+		}
+	}
+
+	@Hook(value = Pointcut.SERVER_OUTGOING_RESPONSE)
+	public void interceptOutgoingResponse(RequestDetails theRequestDetails, ResponseDetails theResponseDetails) {
+		if (theResponseDetails.getResponseResource() == null) {
+			return;
+		}
+		if (isRequestAuthorized(theRequestDetails)) {
+			return;
+		}
+		if (isAllowListedRequest(theRequestDetails)) {
+			return;
+		}
+		if (isSkipServiceForRequest(theRequestDetails)) {
+			return;
+		}
+		if (myConsentService.isEmpty()) {
+			return;
+		}
+
+		// Take care of outer resource first
+		IdentityHashMap<IBaseResource, ConsentOperationStatusEnum> alreadySeenResources =
+				getAlreadySeenResourcesMap(theRequestDetails);
+		if (alreadySeenResources.containsKey(theResponseDetails.getResponseResource())) {
+			// we've already seen this resource before
+			ConsentOperationStatusEnum decisionOnResource =
+					alreadySeenResources.get(theResponseDetails.getResponseResource());
+
+			if (ConsentOperationStatusEnum.AUTHORIZED.equals(decisionOnResource)
+					|| ConsentOperationStatusEnum.REJECT.equals(decisionOnResource)) {
+				// the consent service decision on the resource was AUTHORIZED or REJECT.
+				// In both cases, we can immediately return without checking children
+				return;
+			}
+		} else {
+			// we haven't seen this resource before
+			// mark it as seen now, set the initial consent decision value to PROCEED by default,
+			// we will update if it changes another value below
+			alreadySeenResources.put(theResponseDetails.getResponseResource(), ConsentOperationStatusEnum.PROCEED);
+
+			for (IConsentEnforcementService next : myConsentService) {
+				final ConsentOutcome outcome = next.willSeeResource(
+						theRequestDetails, theResponseDetails.getResponseResource(), myContextConsentServices);
+				if (outcome.getResource() != null) {
+					theResponseDetails.setResponseResource(outcome.getResource());
+				}
+
+				// Clear the total
+				if (theResponseDetails.getResponseResource() instanceof IBaseBundle) {
+					BundleUtil.setTotal(
+							theRequestDetails.getFhirContext(),
+							(IBaseBundle) theResponseDetails.getResponseResource(),
+							null);
+				}
+
+				switch (outcome.getStatus()) {
+					case REJECT:
+						alreadySeenResources.put(
+								theResponseDetails.getResponseResource(), ConsentOperationStatusEnum.REJECT);
+						if (outcome.getOperationOutcome() != null) {
+							theResponseDetails.setResponseResource(outcome.getOperationOutcome());
+						} else {
+							theResponseDetails.setResponseResource(null);
+							theResponseDetails.setResponseCode(Constants.STATUS_HTTP_204_NO_CONTENT);
+						}
+						// Return immediately
+						return;
+					case AUTHORIZED:
+						alreadySeenResources.put(
+								theResponseDetails.getResponseResource(), ConsentOperationStatusEnum.AUTHORIZED);
+						// Don't check children, so return immediately
+						return;
+					case PROCEED:
+						// Check children, so proceed
+						break;
+				}
+			}
+		}
+
+		// See child resources
+		IBaseResource outerResource = theResponseDetails.getResponseResource();
+		FhirContext ctx = theRequestDetails.getServer().getFhirContext();
+		IModelVisitor2 visitor = new IModelVisitor2() {
+			@Override
+			public boolean acceptElement(
+					IBase theElement,
+					List<IBase> theContainingElementPath,
+					List<BaseRuntimeChildDefinition> theChildDefinitionPath,
+					List<BaseRuntimeElementDefinition<?>> theElementDefinitionPath) {
+
+				// Clear the total
+				if (theElement instanceof IBaseBundle) {
+					BundleUtil.setTotal(theRequestDetails.getFhirContext(), (IBaseBundle) theElement, null);
+				}
+
+				if (theElement == outerResource) {
+					return true;
+				}
+				if (theElement instanceof IBaseResource) {
+					IBaseResource resource = (IBaseResource) theElement;
+					if (alreadySeenResources.putIfAbsent(resource, ConsentOperationStatusEnum.PROCEED) != null) {
+						return true;
+					}
+
+					boolean shouldCheckChildren = true;
+					for (IConsentEnforcementService next : myConsentService) {
+						ConsentOutcome childOutcome =
+								next.willSeeResource(theRequestDetails, resource, myContextConsentServices);
+
+						IBaseResource replacementResource = null;
+						boolean shouldReplaceResource = false;
+
+						switch (childOutcome.getStatus()) {
+							case REJECT:
+								replacementResource = childOutcome.getOperationOutcome();
+								shouldReplaceResource = true;
+								alreadySeenResources.put(resource, ConsentOperationStatusEnum.REJECT);
+								break;
+							case PROCEED:
+								replacementResource = childOutcome.getResource();
+								shouldReplaceResource = replacementResource != null;
+								break;
+							case AUTHORIZED:
+								replacementResource = childOutcome.getResource();
+								shouldReplaceResource = replacementResource != null;
+								shouldCheckChildren = false;
+								alreadySeenResources.put(resource, ConsentOperationStatusEnum.AUTHORIZED);
+								break;
+						}
+
+						if (shouldReplaceResource) {
+							IBase container = theContainingElementPath.get(theContainingElementPath.size() - 2);
+							BaseRuntimeChildDefinition containerChildElement =
+									theChildDefinitionPath.get(theChildDefinitionPath.size() - 1);
+							containerChildElement.getMutator().setValue(container, replacementResource);
+							resource = replacementResource;
+						}
+					}
+
+					return shouldCheckChildren;
+				}
+
+				return true;
+			}
+
+			@Override
+			public boolean acceptUndeclaredExtension(
+					IBaseExtension<?, ?> theNextExt,
+					List<IBase> theContainingElementPath,
+					List<BaseRuntimeChildDefinition> theChildDefinitionPath,
+					List<BaseRuntimeElementDefinition<?>> theElementDefinitionPath) {
+				return true;
+			}
+		};
+		ctx.newTerser().visit(outerResource, visitor);
+	}
+
+	@Hook(value = Pointcut.SERVER_HANDLE_EXCEPTION)
+	public void requestFailed(RequestDetails theRequest, BaseServerResponseException theException) {
+		theRequest.getUserData().put(myRequestCompletedKey, Boolean.TRUE);
+		for (IConsentEnforcementService next : myConsentService) {
+			next.completeOperationFailure(theRequest, theException, myContextConsentServices);
+		}
+	}
+
+	@Hook(value = Pointcut.SERVER_PROCESSING_COMPLETED_NORMALLY)
+	public void requestSucceeded(RequestDetails theRequest) {
+		if (Boolean.TRUE.equals(theRequest.getUserData().get(myRequestCompletedKey))) {
+			return;
+		}
+		for (IConsentEnforcementService next : myConsentService) {
+			next.completeOperationSuccess(theRequest, myContextConsentServices);
+		}
+	}
+
+	protected RequestDetails getRequestDetailsForCurrentExportOperation(
+			BulkExportJobParameters theParameters, IBaseResource theBaseResource) {
+		// bulk exports are system operations
+		SystemRequestDetails details = new SystemRequestDetails();
+		return details;
+	}
+
+	@Hook(value = Pointcut.STORAGE_BULK_EXPORT_RESOURCE_INCLUSION)
+	public boolean shouldBulkExportIncludeResource(BulkExportJobParameters theParameters, IBaseResource theResource) {
+		RequestDetails requestDetails = getRequestDetailsForCurrentExportOperation(theParameters, theResource);
+
+		for (IConsentEnforcementService next : myConsentService) {
+			ConsentOutcome nextOutcome = next.canSeeResource(requestDetails, theResource, myContextConsentServices);
+			ConsentOperationStatusEnum status = nextOutcome.getStatus();
+			if (ConsentOperationStatusEnum.REJECT.equals(status)) {
+				// if any consent service rejects, reject the resource
+				return false;
+			}
+
+			nextOutcome = next.willSeeResource(requestDetails, theResource, myContextConsentServices);
+			status = nextOutcome.getStatus();
+			if (ConsentOperationStatusEnum.REJECT.equals(status)) {
+				// if any consent service rejects, reject the resource
+				return false;
+			}
+		}
+
+		// default is to include the resource
+		return true;
+	}
+
+	private boolean isRequestAuthorized(RequestDetails theRequestDetails) {
+		boolean retVal = false;
+		if (theRequestDetails != null) {
+			Object authorizedObj = theRequestDetails.getUserData().get(myRequestAuthorizedKey);
+			retVal = Boolean.TRUE.equals(authorizedObj);
+		}
+		return retVal;
+	}
+
+	private boolean isSkipServiceForRequest(RequestDetails theRequestDetails) {
+		return isMetadataPath(theRequestDetails) || isMetaOperation(theRequestDetails);
+	}
+
+	private boolean isAllowListedRequest(RequestDetails theRequestDetails) {
+		return isMetadataPath(theRequestDetails) || isMetaOperation(theRequestDetails);
+	}
+
+	private boolean isMetaOperation(RequestDetails theRequestDetails) {
+		return theRequestDetails != null && OPERATION_META.equals(theRequestDetails.getOperation());
+	}
+
+	private boolean isMetadataPath(RequestDetails theRequestDetails) {
+		return theRequestDetails != null && URL_TOKEN_METADATA.equals(theRequestDetails.getRequestPath());
+	}
+
+	private void validateParameter(Map<String, String[]> theParameterMap) {
+		if (theParameterMap != null) {
+			if (theParameterMap.containsKey(Constants.PARAM_SEARCH_TOTAL_MODE)
+					&& Arrays.stream(theParameterMap.get("_total")).anyMatch("accurate"::equals)) {
+				throw new InvalidRequestException(Msg.code(2037) + Constants.PARAM_SEARCH_TOTAL_MODE
+						+ "=accurate is not permitted on this server");
+			}
+			if (theParameterMap.containsKey(Constants.PARAM_SUMMARY)
+					&& Arrays.stream(theParameterMap.get("_summary")).anyMatch("count"::equals)) {
+				throw new InvalidRequestException(
+						Msg.code(2038) + Constants.PARAM_SUMMARY + "=count is not permitted on this server");
+			}
+		}
+	}
+
+	/**
+	 * The map returned by this method keeps track of the resources already processed by ConsentInterceptor in the
+	 * context of a request.
+	 * If the map contains a particular resource, it means that the resource has already been processed and the value
+	 * is the status returned by consent services for that resource.
+	 * @param theRequestDetails
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	private IdentityHashMap<IBaseResource, ConsentOperationStatusEnum> getAlreadySeenResourcesMap(
+			RequestDetails theRequestDetails) {
+		IdentityHashMap<IBaseResource, ConsentOperationStatusEnum> alreadySeenResources =
+				(IdentityHashMap<IBaseResource, ConsentOperationStatusEnum>)
+						theRequestDetails.getUserData().get(myRequestSeenResourcesKey);
+		if (alreadySeenResources == null) {
+			alreadySeenResources = new IdentityHashMap<>();
+			theRequestDetails.getUserData().put(myRequestSeenResourcesKey, alreadySeenResources);
+		}
+		return alreadySeenResources;
+	}
+
+	private static ForbiddenOperationException toForbiddenOperationException(ConsentOutcome theOutcome) {
+		IBaseOperationOutcome operationOutcome = null;
+		if (theOutcome.getOperationOutcome() != null) {
+			operationOutcome = theOutcome.getOperationOutcome();
+		}
+		return new ForbiddenOperationException("Rejected by consent service", operationOutcome);
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementInterceptor.java
@@ -581,11 +581,11 @@ public class ConsentEnforcementInterceptor {
 	}
 
 	private boolean isSkipServiceForRequest(RequestDetails theRequestDetails) {
-		return isMetadataPath(theRequestDetails) || isMetaOperation(theRequestDetails);
+		return isMetadataPath(theRequestDetails) || isMetaOperation(theRequestDetails) || isDocsPath(theRequestDetails);
 	}
 
 	private boolean isAllowListedRequest(RequestDetails theRequestDetails) {
-		return isMetadataPath(theRequestDetails) || isMetaOperation(theRequestDetails);
+		return isMetadataPath(theRequestDetails) || isMetaOperation(theRequestDetails) || isDocsPath(theRequestDetails);
 	}
 
 	private boolean isMetaOperation(RequestDetails theRequestDetails) {
@@ -594,6 +594,22 @@ public class ConsentEnforcementInterceptor {
 
 	private boolean isMetadataPath(RequestDetails theRequestDetails) {
 		return theRequestDetails != null && URL_TOKEN_METADATA.equals(theRequestDetails.getRequestPath());
+	}
+
+	/**
+	 * Kecualikan endpoint dokumentasi API (Swagger UI / OpenAPI docs) dari consent check,
+	 * supaya bisa dibuka di browser tanpa perlu header X-Organization-ID. Ini bukan resource
+	 * FHIR/PHI, jadi aman dikecualikan.
+	 */
+	private boolean isDocsPath(RequestDetails theRequestDetails) {
+		if (theRequestDetails == null || theRequestDetails.getRequestPath() == null) {
+			return false;
+		}
+		String path = theRequestDetails.getRequestPath();
+		return path.equals("api-docs")
+				|| path.startsWith("api-docs")
+				|| path.startsWith("swagger-ui")
+				|| path.startsWith("swagger");
 	}
 
 	private void validateParameter(Map<String, String[]> theParameterMap) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementService.java
@@ -1,0 +1,84 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+import ca.uhn.fhir.rest.server.interceptor.consent.IConsentContextServices;
+import ca.uhn.fhir.rest.server.interceptor.consent.IConsentService;
+
+import java.util.ArrayList;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.AuditEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConsentEnforcementService implements IConsentService {
+    private LoaderWithCache loader;
+    private String orgId;
+    private PolicyEvaluator policyEvaluator;
+
+    @Autowired
+    private DaoRegistry daoRegistry;
+
+    @Autowired
+    private ConsentProperties consentProperties;
+
+    @Autowired
+    private FhirContext fhirContext;
+
+    @Override
+    public ConsentOutcome startOperation(RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+        // Authrization using Organization ID
+        String userOrgId = theRequestDetails.getHeader(consentProperties.getOrganizationRequestHeader());
+        if (userOrgId == null || userOrgId.isEmpty()) {
+            // TOLAK Jika tidak ada ID organisasi di header
+            return ConsentOutcome.REJECT;
+        }
+
+        // Front Service hanya mengirimkan X-Organization-ID yang benar, jadi tidak perlu dicek
+        this.orgId = userOrgId;
+
+        this.loader = new LoaderWithCache(consentProperties);
+        this.loader.setFhirContext(fhirContext);
+
+        // load daftar consent berdasarkan Organisasi
+        this.policyEvaluator = new PolicyEvaluator(PolicyEvaluator.EVALUATION_SCOPE_ORGANIZATION, loader.getConsentList(consentProperties.getEnvironment(), orgId));
+
+        return ConsentOutcome.PROCEED;
+    }
+
+    @Override
+    public ConsentOutcome canSeeResource(RequestDetails theRequestDetails, IBaseResource theResource,
+            IConsentContextServices theContextServices) {
+        String patientId = Utils.getPatientId(theResource);
+        policyEvaluator.setPatientId(patientId);
+        return policyEvaluator.evaluate(theResource, ActionEnum.ACCESS, new ArrayList<String>());
+    }
+
+    @Override
+    public ConsentOutcome willSeeResource(RequestDetails theRequestDetails, IBaseResource theResource,
+            IConsentContextServices theContextServices) {
+        String patientId = Utils.getPatientId(theResource);
+        policyEvaluator.setPatientId(patientId);
+        return policyEvaluator.evaluate(theResource, ActionEnum.READ, new ArrayList<String>());
+    }
+
+    @Override
+    public void completeOperationFailure(RequestDetails theRequestDetails, BaseServerResponseException theException,
+            IConsentContextServices theContextServices) {
+        try {
+            IFhirResourceDao<AuditEvent> auditEventDao = daoRegistry.getResourceDao(AuditEvent.class);
+
+            AuditEventLogger logger = new AuditEventLogger(auditEventDao, orgId, consentProperties);
+            logger.createForFailedOperation(theRequestDetails, theException, theContextServices);
+        } catch (Exception e) {
+            // Log error but don't throw to avoid interfering with the original exception
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentEnforcementService.java
@@ -7,7 +7,6 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
 import ca.uhn.fhir.rest.server.interceptor.consent.IConsentContextServices;
-import ca.uhn.fhir.rest.server.interceptor.consent.IConsentService;
 
 import java.util.ArrayList;
 
@@ -17,7 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ConsentEnforcementService implements IConsentService {
+public class ConsentEnforcementService implements IConsentEnforcementService {
     private LoaderWithCache loader;
     private String orgId;
     private PolicyEvaluator policyEvaluator;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentInterceptorConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentInterceptorConfig.java
@@ -1,0 +1,27 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Wires {@link ConsentEnforcementInterceptor} as a Spring-managed bean and connects it to
+ * {@link ConsentEnforcementService}.
+ * <p>
+ * This bean is picked up by {@code StarterJpaConfig#registerCustomInterceptors} via
+ * {@code hapi.fhir.custom-interceptor-classes} (see application.yaml). Because it is resolved
+ * from the Spring {@code ApplicationContext} (and not instantiated via reflection), the
+ * {@link ConsentEnforcementService} dependency below is properly injected and registered
+ * before the interceptor is attached to the {@code RestfulServer}.
+ * </p>
+ */
+@Configuration
+public class ConsentInterceptorConfig {
+
+	@Bean
+	public ConsentEnforcementInterceptor consentEnforcementInterceptor(
+			ConsentEnforcementService theConsentEnforcementService) {
+		ConsentEnforcementInterceptor interceptor = new ConsentEnforcementInterceptor();
+		interceptor.registerConsentService(theConsentEnforcementService);
+		return interceptor;
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentProperties.java
@@ -57,7 +57,16 @@ public class ConsentProperties {
     /**
      * URL for consent registry service
      */
+    // TODO: ganti ini dengan ENV VARIABLE AGAR DINAMIS TIDAK HARDCODE
     private String urlConsentRegistry = "http://localhost:7272/api/consent";
+
+    /**
+     * Shared secret untuk otentikasi endpoint invalidasi cache consent
+     * (dipanggil oleh consent registry setiap ada perubahan Consent/Provision).
+     * Kosong secara default - endpoint invalidasi akan menolak semua request
+     * kalau secret ini belum di-set (fail-closed).
+     */
+    private String cacheInvalidationSecret = "";
 
     public String getEnvironment() {
         return environment;
@@ -105,6 +114,14 @@ public class ConsentProperties {
 
     public void setUrlConsentRegistry(String urlConsentRegistry) {
         this.urlConsentRegistry = urlConsentRegistry;
+    }
+
+    public String getCacheInvalidationSecret() {
+        return cacheInvalidationSecret;
+    }
+
+    public void setCacheInvalidationSecret(String cacheInvalidationSecret) {
+        this.cacheInvalidationSecret = cacheInvalidationSecret;
     }
 
     /**

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ConsentProperties.java
@@ -1,0 +1,138 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.FamilyMemberHistory;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Procedure;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.Immunization;
+import org.hl7.fhir.r4.model.AllergyIntolerance;
+import org.hl7.fhir.r4.model.ClinicalImpression;
+import org.hl7.fhir.r4.model.CarePlan;
+import org.hl7.fhir.r4.model.NutritionOrder;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.hl7.fhir.r4.model.Substance;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.RiskAssessment;
+import org.hl7.fhir.r4.model.ImagingStudy;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties for Consent Enforcement Interceptor
+ */
+@Configuration
+@ConfigurationProperties(prefix = "hapi.policy")
+public class ConsentProperties {
+    /**
+     * Organization ID for KEMENKES managing organization
+     */
+    private String environment = "dev";
+
+    /**
+     * Header name for administrator access
+     */
+    private String administratorRequestHeader = "X-Administrator-Access";
+
+    /**
+     * Header name for organization ID
+     */
+    private String organizationRequestHeader = "X-Organization-ID";
+
+    /**
+     * Security system name for organization ID
+     */
+    private String organizationSecuritySystemName = "http://terminology.kemkes.go.id/org-id";
+
+    /**
+     * Organization ID for KEMENKES managing organization
+     */
+    private String organizationManagingIdKemenkes = "9900000000";
+
+    /**
+     * URL for consent registry service
+     */
+    private String urlConsentRegistry = "http://localhost:7272/api/consent";
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+    
+    public String getAdministratorRequestHeader() {
+        return administratorRequestHeader;
+    }
+
+    public void setAdministratorRequestHeader(String administratorRequestHeader) {
+        this.administratorRequestHeader = administratorRequestHeader;
+    }
+
+    public String getOrganizationRequestHeader() {
+        return organizationRequestHeader;
+    }
+
+    public void setOrganizationRequestHeader(String organizationRequestHeader) {
+        this.organizationRequestHeader = organizationRequestHeader;
+    }
+
+    public String getOrganizationSecuritySystemName() {
+        return organizationSecuritySystemName;
+    }
+
+    public void setOrganizationSecuritySystemName(String organizationSecuritySystemName) {
+        this.organizationSecuritySystemName = organizationSecuritySystemName;
+    }
+
+    public String getOrganizationManagingIdKemenkes() {
+        return organizationManagingIdKemenkes;
+    }
+
+    public void setOrganizationManagingIdKemenkes(String organizationManagingIdKemenkes) {
+        this.organizationManagingIdKemenkes = organizationManagingIdKemenkes;
+    }
+
+    public String getUrlConsentRegistry() {
+        return urlConsentRegistry;
+    }
+
+    public void setUrlConsentRegistry(String urlConsentRegistry) {
+        this.urlConsentRegistry = urlConsentRegistry;
+    }
+
+    /**
+     * Get FHIR resource whitelist for read access
+     */
+    public List<Class<? extends DomainResource>> getFhirResourceWhitelist() {
+        List<Class<? extends DomainResource>> whitelist = new ArrayList<>();
+        whitelist.add(AllergyIntolerance.class);
+        whitelist.add(FamilyMemberHistory.class);
+        whitelist.add(Substance.class);
+        return whitelist;
+    }
+
+    public List<Class<? extends DomainResource>> getFhirResourceHasEncounter() {
+        List<Class<? extends DomainResource>> resources = new ArrayList<>();
+        resources.add(Condition.class);
+        resources.add(Procedure.class);
+        resources.add(QuestionnaireResponse.class);
+        resources.add(Immunization.class);
+        resources.add(ClinicalImpression.class);
+        resources.add(CarePlan.class);
+        resources.add(NutritionOrder.class);
+        resources.add(ServiceRequest.class);
+        resources.add(DiagnosticReport.class);
+        resources.add(Observation.class);
+        resources.add(MedicationRequest.class);
+        resources.add(RiskAssessment.class);
+        resources.add(ImagingStudy.class);
+        return resources;
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/Constants.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/Constants.java
@@ -1,0 +1,117 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.EventDefinition;
+import org.hl7.fhir.r4.model.FamilyMemberHistory;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Procedure;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.ResearchDefinition;
+import org.hl7.fhir.r4.model.Immunization;
+import org.hl7.fhir.r4.model.ImplementationGuide;
+import org.hl7.fhir.r4.model.AllergyIntolerance;
+import org.hl7.fhir.r4.model.ClinicalImpression;
+import org.hl7.fhir.r4.model.CodeSystem;
+import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.ConceptMap;
+import org.hl7.fhir.r4.model.CarePlan;
+import org.hl7.fhir.r4.model.NutritionOrder;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.hl7.fhir.r4.model.StructureDefinition;
+import org.hl7.fhir.r4.model.StructureMap;
+import org.hl7.fhir.r4.model.Substance;
+import org.hl7.fhir.r4.model.TerminologyCapabilities;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.GraphDefinition;
+
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.OperationDefinition;
+import org.hl7.fhir.r4.model.PlanDefinition;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.MedicationStatement;
+import org.hl7.fhir.r4.model.NamingSystem;
+import org.hl7.fhir.r4.model.MedicationAdministration;
+import org.hl7.fhir.r4.model.MedicationDispense;
+import org.hl7.fhir.r4.model.RiskAssessment;
+import org.hl7.fhir.r4.model.SearchParameter;
+import org.hl7.fhir.r4.model.ImagingStudy;
+
+public final class Constants {
+    public final static String ADMINISTRATOR_REQUEST_HEADER = "X-Administrator-Access";
+    public final static String ORGANIZATION_REQUEST_HEADER = "X-Organization-ID";
+    public final static String ORGANIZATION_SECURITY_SYSTEM_NAME = "http://terminology.kemkes.go.id/org-id";
+    public final static String ORGANIZATION_MANAGING_ID_KEMENKES = "9900000000";
+    public final static String PATIENT_SECURITY_SYSTEM_NAME = "http://terminology.kemkes.go.id/patient-id";
+
+    public final static String URLCONSENT_REGISTRY = "http://localhost:7272/api/consent";
+
+    public final static List<Class<? extends DomainResource>> FHIR_RESOURCE_CONFORMANNCE = new ArrayList<Class<? extends DomainResource>>() {
+        {
+            add(CapabilityStatement.class);
+            add(GraphDefinition.class);
+            add(StructureDefinition.class);
+            add(ImplementationGuide.class);
+            add(OperationDefinition.class);
+            add(SearchParameter.class);
+            add(StructureMap.class);
+        }
+    };
+
+    public final static List<Class<? extends DomainResource>> FHIR_RESOURCE_TERMINOLOGY = new ArrayList<Class<? extends DomainResource>>() {
+        {
+            add(CodeSystem.class);
+            add(ValueSet.class);
+            add(ConceptMap.class);
+            add(NamingSystem.class);
+            add(TerminologyCapabilities.class);
+        }
+    };
+
+    public final static List<Class<? extends DomainResource>> FHIR_RESOURCE_CLINICAL_REASONING = new ArrayList<Class<? extends DomainResource>>() {
+        {
+            add(PlanDefinition.class);
+            add(EventDefinition.class);
+            add(ResearchDefinition.class);
+        }
+    };
+
+    // Boleh 'read' melalui pencarian atau get detail oleh semua organisasi
+    public final static List<Class<? extends DomainResource>> FHIR_RESOURCE_WHITELIST = new ArrayList<Class<? extends DomainResource>>() {
+        {
+            add(AllergyIntolerance.class);
+            add(FamilyMemberHistory.class);
+
+            // Karena keterbatasan DaoRegistry untuk mencari ServiceRequest di sub-sub-parameter processing.aditive, 
+            // maka sementara Substance masuk WHITELIST sampai ditemukan metode yang efisien untuk mencari ServiceRequest
+            add(Substance.class);
+        }
+    };
+
+    // Resource yang memiliki reference langsung ke Encounter
+    public final static List<Class<? extends DomainResource>> FHIR_RESOURCE_HAS_ENCOUNTER = new ArrayList<Class<? extends DomainResource>>() {
+        {
+            add(Condition.class);
+            add(Procedure.class);
+            add(QuestionnaireResponse.class);
+            add(Immunization.class);
+            add(ClinicalImpression.class);
+            add(CarePlan.class);
+            add(NutritionOrder.class);
+            add(ServiceRequest.class);
+            add(DiagnosticReport.class);
+            add(Observation.class);
+            add(MedicationRequest.class);
+            add(MedicationStatement.class);
+            add(MedicationAdministration.class);
+            add(MedicationDispense.class);
+            add(RiskAssessment.class);
+            add(Composition.class);
+            add(ImagingStudy.class);
+        }
+    };
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ErrorResponse.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ErrorResponse.java
@@ -1,0 +1,11 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+public class ErrorResponse {
+    public int httpCode;
+    public int errorCode;
+    public String errorName;
+    public String message;
+    public Object data;
+    public String[] stack;
+    public String details;
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/IConsentEnforcementService.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/IConsentEnforcementService.java
@@ -1,0 +1,209 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOperationStatusEnum;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+import ca.uhn.fhir.rest.server.interceptor.consent.IConsentContextServices;
+
+/**
+ * This interface is intended to be implemented as the user-defined contract for
+ * the {@link ConsentEnforcementInterceptor}.
+ * <p>
+ * Note: Since HAPI FHIR 5.1.0, methods in this interface have default methods that return {@link ConsentOutcome#PROCEED}
+ * </p>
+ * <p>
+ * See <a href="https://hapifhir.io/hapi-fhir/docs/security/consent_interceptor.html">Consent Interceptor</a> for
+ * more information on this interceptor.
+ * </p>
+ */
+public interface IConsentEnforcementService {
+    /**
+	 * This method is called when an operation is initially beginning, before any
+	 * significant processing occurs. The service may use this method to decide
+	 * whether the request needs to be reviewed further or not.
+	 *
+	 * @param theRequestDetails  Contains details about the operation that is
+	 *                           beginning, including details about the request type,
+	 *                           URL, etc. Note that the RequestDetails has a generic
+	 *                           Map (see {@link RequestDetails#getUserData()}) that
+	 *                           can be used to store information and state to be
+	 *                           passed between methods in the consent service.
+	 * @param theContextServices An object passed in by the consent framework that
+	 *                           provides utility functions relevant to acting on
+	 *                           consent directives.
+	 * @return An outcome object. See {@link ConsentOutcome}
+	 */
+	default ConsentOutcome startOperation(
+			RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+		return ConsentOutcome.PROCEED;
+	}
+
+	/**
+	 * This method will be invoked once prior to invoking {@link #canSeeResource(RequestDetails, IBaseResource, IConsentContextServices)}
+	 * and can be used to skip that phase.
+	 * <p>
+	 * If this method returns {@literal false} (default is {@literal true}) {@link #willSeeResource(RequestDetails, IBaseResource, IConsentContextServices)}
+	 * will be invoked for this request, but {@link #canSeeResource(RequestDetails, IBaseResource, IConsentContextServices)} will not.
+	 * </p>
+	 *
+	 * @param theRequestDetails  Contains details about the operation that is
+	 *                           beginning, including details about the request type,
+	 *                           URL, etc. Note that the RequestDetails has a generic
+	 *                           Map (see {@link RequestDetails#getUserData()}) that
+	 *                           can be used to store information and state to be
+	 *                           passed between methods in the consent service.
+	 * @param theContextServices An object passed in by the consent framework that
+	 *                           provides utility functions relevant to acting on
+	 *                           consent directives.
+	 * @return Returns {@literal false} to avoid calling {@link #canSeeResource(RequestDetails, IBaseResource, IConsentContextServices)}
+	 * @since 6.0.0
+	 */
+	default boolean shouldProcessCanSeeResource(
+			RequestDetails theRequestDetails, IConsentContextServices theContextServices) {
+		return true;
+	}
+
+	/**
+	 * This method is called if a user may potentially see a resource via READ
+	 * operations, SEARCH operations, etc. This method may make decisions about
+	 * whether or not the user should be permitted to see the resource.
+	 * <p>
+	 * Implementations should make no attempt to modify the returned result within
+	 * this method. For modification use cases (e.g. masking for consent rules) the
+	 * user should use the {@link #willSeeResource(RequestDetails, IBaseResource, IConsentContextServices)}
+	 * method to actually make changes. This method is intended to only
+	 * to make decisions.
+	 * </p>
+	 * <p>
+	 * In addition, the {@link ConsentOutcome} must return one of the following
+	 * statuses:
+	 * </p>
+	 * <ul>
+	 * <li>{@link ConsentOperationStatusEnum#AUTHORIZED}: The resource will be returned to the client. If multiple consent service implementation are present, no further implementations will be invoked for this resource. {@link #willSeeResource(RequestDetails, IBaseResource, IConsentContextServices)} will not be invoked for this resource.</li>
+	 * <li>{@link ConsentOperationStatusEnum#PROCEED}: The resource will be returned to the client.</li>
+	 * <li>{@link ConsentOperationStatusEnum#REJECT}: The resource will be stripped from the response. If multiple consent service implementation are present, no further implementations will be invoked for this resource. {@link #willSeeResource(RequestDetails, IBaseResource, IConsentContextServices)} will not be invoked for this resource.</li>
+	 * </ul>
+	 * </p>
+	 * <p>
+	 *    There are two methods the consent service may use to suppress or modify response resources:
+	 * </p>
+	 * <ul>
+	 *    <li>{@link #canSeeResource(RequestDetails, IBaseResource, IConsentContextServices)} should be used to remove resources from results in scenarios where it is important to not reveal existence of those resources. It is called prior to any paging logic, so result pages will still be normal sized even if results are filtered.</li>
+	 *    <li>{@link #willSeeResource(RequestDetails, IBaseResource, IConsentContextServices)} should be used to filter individual elements from resources, or to remove entire resources in cases where it is not important to conceal their existence. It is called after paging logic, so any resources removed by this method may result in abnormally sized result pages. However, removing resourced using this method may also perform better so it is preferable for use in cases where revealing resource existence is not a concern.</li>
+	 * </ul>
+	 * <p>
+	 * <b>Performance note:</b> Note that this method should be efficient, since it will be called once
+	 * for every resource potentially returned (e.g. by searches). If this method
+	 * takes a significant amount of time to execute, performance on the server
+	 * will suffer.
+	 * </p>
+	 *
+	 *
+	 * @param theRequestDetails  Contains details about the operation that is
+	 *                           beginning, including details about the request type,
+	 *                           URL, etc. Note that the RequestDetails has a generic
+	 *                           Map (see {@link RequestDetails#getUserData()}) that
+	 *                           can be used to store information and state to be
+	 *                           passed between methods in the consent service.
+	 * @param theResource        The resource that will be exposed
+	 * @param theContextServices An object passed in by the consent framework that
+	 *                           provides utility functions relevant to acting on
+	 *                           consent directives.
+	 * @return An outcome object. See {@link ConsentOutcome}. Note that this method is not allowed
+	 * to modify the response object, so an error will be thrown if {@link ConsentOutcome#getResource()}
+	 * returns a non-null response.
+	 */
+	default ConsentOutcome canSeeResource(
+			RequestDetails theRequestDetails, IBaseResource theResource, IConsentContextServices theContextServices) {
+		return ConsentOutcome.PROCEED;
+	}
+
+	/**
+	 * This method is called if a user is about to see a resource, either completely
+	 * or partially. In other words, if the user is going to see any part of this resource
+	 * via READ operations, SEARCH operations, etc., this method is
+	 * called. This method may modify the resource in order to filter/mask aspects of
+	 * the contents, or even to enrich it.
+	 * <p>
+	 * The returning {@link ConsentOutcome} may optionally replace the resource
+	 * with a different resource (including an OperationOutcome) by calling the
+	 * resource property on the {@link ConsentOutcome}.
+	 * </p>
+	 * <p>
+	 * In addition, the {@link ConsentOutcome} must return one of the following
+	 * statuses:
+	 * </p>
+	 * <ul>
+	 * <li>{@link ConsentOperationStatusEnum#AUTHORIZED}: The resource will be returned to the client. If multiple consent service implementation are present, no further implementations will be invoked for this resource.</li>
+	 * <li>{@link ConsentOperationStatusEnum#PROCEED}: The resource will be returned to the client.</li>
+	 * <li>{@link ConsentOperationStatusEnum#REJECT}: The resource will not be returned to the client. If multiple consent service implementation are present, no further implementations will be invoked for this resource.</li>
+	 * </ul>
+	 *
+	 * @param theRequestDetails  Contains details about the operation that is
+	 *                           beginning, including details about the request type,
+	 *                           URL, etc. Note that the RequestDetails has a generic
+	 *                           Map (see {@link RequestDetails#getUserData()}) that
+	 *                           can be used to store information and state to be
+	 *                           passed between methods in the consent service.
+	 * @param theResource        The resource that will be exposed
+	 * @param theContextServices An object passed in by the consent framework that
+	 *                           provides utility functions relevant to acting on
+	 *                           consent directives.
+	 * @return An outcome object. See method documentation for a description.
+	 * @see #canSeeResource(RequestDetails, IBaseResource, IConsentContextServices) for a description of the difference between these two methods.
+	 */
+	default ConsentOutcome willSeeResource(
+			RequestDetails theRequestDetails, IBaseResource theResource, IConsentContextServices theContextServices) {
+		return ConsentOutcome.PROCEED;
+	}
+
+	/**
+	 * This method is called when an operation is complete. It can be used to perform
+	 * any necessary cleanup, flush audit events, etc.
+	 * <p>
+	 * This method is not called if the request failed. {@link #completeOperationFailure(RequestDetails, BaseServerResponseException, IConsentContextServices)}
+	 * will be called instead in that case.
+	 * </p>
+	 *
+	 * @param theRequestDetails  Contains details about the operation that is
+	 *                           beginning, including details about the request type,
+	 *                           URL, etc. Note that the RequestDetails has a generic
+	 *                           Map (see {@link RequestDetails#getUserData()}) that
+	 *                           can be used to store information and state to be
+	 *                           passed between methods in the consent service.
+	 * @param theContextServices An object passed in by the consent framework that
+	 *                           provides utility functions relevant to acting on
+	 *                           consent directives.
+	 * @see #completeOperationFailure(RequestDetails, BaseServerResponseException, IConsentContextServices)
+	 */
+	default void completeOperationSuccess(
+			RequestDetails theRequestDetails, IConsentContextServices theContextServices) {}
+
+	/**
+	 * This method is called when an operation is complete. It can be used to perform
+	 * any necessary cleanup, flush audit events, etc.
+	 * <p>
+	 * This method will be called if the request did not complete successfully, instead of
+	 * {@link #completeOperationSuccess(RequestDetails, IConsentContextServices)}. Typically this means that
+	 * the operation failed and a failure is being returned to the client.
+	 * </p>
+	 *
+	 * @param theRequestDetails  Contains details about the operation that is
+	 *                           beginning, including details about the request type,
+	 *                           URL, etc. Note that the RequestDetails has a generic
+	 *                           Map (see {@link RequestDetails#getUserData()}) that
+	 *                           can be used to store information and state to be
+	 *                           passed between methods in the consent service.
+	 * @param theContextServices An object passed in by the consent framework that
+	 *                           provides utility functions relevant to acting on
+	 *                           consent directives.
+	 * @see #completeOperationSuccess(RequestDetails, IConsentContextServices)
+	 */
+	default void completeOperationFailure(
+			RequestDetails theRequestDetails,
+			BaseServerResponseException theException,
+			IConsentContextServices theContextServices) {}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/LoaderWithCache.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/LoaderWithCache.java
@@ -1,0 +1,145 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.IdType;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.starter.interceptors.CacheService.CacheEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+
+public class LoaderWithCache {
+    private CacheService cache = new CacheService();
+    private ConsentProperties consentProperties;
+    private DaoRegistry resourceDaoRegistry;
+    private FhirContext fhirContext;
+    private RestTemplate restTemplate = new RestTemplate();
+
+    public LoaderWithCache(ConsentProperties consentProperties) {
+        this.consentProperties = consentProperties;
+    }
+
+    public void setResourceDaoRegistry(DaoRegistry resourceDaoRegistry) {
+        this.resourceDaoRegistry = resourceDaoRegistry;
+    }
+
+    public void setFhirContext(FhirContext fhirContext) {
+        this.fhirContext = fhirContext;
+    }
+
+    public <T extends IBaseResource> T getResource(String resourceId, Class<? extends T> clz, RequestDetails theRequestDetails) {
+        if (resourceId == null)
+            return null;
+
+        CacheEnum cacheEnum = CacheEnum.fromResourceType(clz.getName());
+        if (cacheEnum == null)
+            return null;
+
+        // Ambil dari Memory Cache jika ada
+        T resource = cache.getIfPresent(cacheEnum, resourceId);
+        if (resource == null) {
+            // Ambil dari DaoRegistry
+            resource = loadResourceFromDaoRegistry(resourceId, theRequestDetails);
+        }
+
+        if (resource != null) {
+            // Simpan ke Cache
+            cache.put(cacheEnum, resourceId, resource);
+        }
+        
+        return resource;
+    }
+
+    private <T extends IBaseResource> T loadResourceFromDaoRegistry(String resourceId, RequestDetails theRequestDetails) {
+        try {
+            IFhirResourceDao<T> resourceDao = (IFhirResourceDao<T>) resourceDaoRegistry.getResourceDao(Encounter.class);
+            return resourceDao.read(new IdType(resourceId), theRequestDetails);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public List<Consent> getConsentList(String env, String orgId) {
+        // Ambil dari Memory Cache jika ada
+        List<Consent> consents = cache.getIfPresent(CacheEnum.CONSENT_LIST, orgId);
+        if (consents == null) {
+            // Ambil dari ConsentRegistry
+            consents = loadConsentListFromRegistry(env, orgId);
+
+            if (consents != null && consents.size() > 0) {
+                // Ambil dari Consent Registry
+                cache.put(CacheEnum.CONSENT_LIST, orgId, consents);
+            }
+        }
+
+        return consents;
+    }
+    
+    private List<Consent> loadConsentListFromRegistry(String env, String orgId) {
+        List<Consent> consents = new ArrayList<Consent>();
+
+        try {
+            String url = consentProperties.getUrlConsentRegistry() + "/search";
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Content-Type", "application/json");
+            headers.set("Accept", "application/json");
+
+            // Create JSON payload
+            Map<String, String> payload = new HashMap<>();
+            payload.put("env", env);
+            payload.put("organization", orgId);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            String jsonPayload = objectMapper.writeValueAsString(payload);
+
+            HttpEntity<String> entity = new HttpEntity<>(jsonPayload, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                entity,
+                String.class
+            );
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                String responseBody = response.getBody();
+
+                if (responseBody.startsWith("{")) {
+                    ErrorResponse errorResponse = objectMapper.readValue(responseBody, ErrorResponse.class);
+                    if (errorResponse.message != null) {
+                        throw new Exception("[Err: " + errorResponse.errorCode + " : HTTP:" + errorResponse.httpCode + "]" + errorResponse.message);
+                    }
+                } else if (responseBody.startsWith("[")) {
+                    Bundle bundle = fhirContext.newJsonParser().parseResource(
+                        Bundle.class, responseBody);
+
+                    for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+                        if (entry.getResource() instanceof Consent) {
+                            consents.add((Consent) entry.getResource());
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return consents;
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/LoaderWithCache.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/LoaderWithCache.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Consent;
-import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.IdType;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -42,11 +41,20 @@ public class LoaderWithCache {
         this.fhirContext = fhirContext;
     }
 
+    /**
+     * Invalidate cache consent list utk satu organisasi. Dipanggil dari luar
+     * (lewat endpoint invalidasi) setiap ada perubahan Consent/Provision di
+     * registry, supaya request berikutnya fetch data fresh, bukan cache lama.
+     */
+    public void invalidateConsentList(String orgId) {
+        cache.invalidate(CacheEnum.CONSENT_LIST, orgId);
+    }
+
     public <T extends IBaseResource> T getResource(String resourceId, Class<? extends T> clz, RequestDetails theRequestDetails) {
         if (resourceId == null)
             return null;
 
-        CacheEnum cacheEnum = CacheEnum.fromResourceType(clz.getName());
+        CacheEnum cacheEnum = CacheEnum.fromResourceType(clz.getSimpleName());
         if (cacheEnum == null)
             return null;
 
@@ -54,7 +62,7 @@ public class LoaderWithCache {
         T resource = cache.getIfPresent(cacheEnum, resourceId);
         if (resource == null) {
             // Ambil dari DaoRegistry
-            resource = loadResourceFromDaoRegistry(resourceId, theRequestDetails);
+            resource = loadResourceFromDaoRegistry(resourceId, clz, theRequestDetails);
         }
 
         if (resource != null) {
@@ -65,11 +73,14 @@ public class LoaderWithCache {
         return resource;
     }
 
-    private <T extends IBaseResource> T loadResourceFromDaoRegistry(String resourceId, RequestDetails theRequestDetails) {
+    private <T extends IBaseResource> T loadResourceFromDaoRegistry(String resourceId, Class<? extends T> clz, RequestDetails theRequestDetails) {
         try {
-            IFhirResourceDao<T> resourceDao = (IFhirResourceDao<T>) resourceDaoRegistry.getResourceDao(Encounter.class);
+            IFhirResourceDao<T> resourceDao = (IFhirResourceDao<T>) resourceDaoRegistry.getResourceDao(clz);
             return resourceDao.read(new IdType(resourceId), theRequestDetails);
         } catch (Exception e) {
+            // Jangan ditelan diam-diam - kalau tidak, resource yang gagal di-fetch
+            // akan selalu terlihat seperti "tidak ditemukan" tanpa penjelasan.
+            e.printStackTrace();
             return null;
         }
     }
@@ -121,18 +132,34 @@ public class LoaderWithCache {
                 String responseBody = response.getBody();
 
                 if (responseBody.startsWith("{")) {
-                    ErrorResponse errorResponse = objectMapper.readValue(responseBody, ErrorResponse.class);
-                    if (errorResponse.message != null) {
-                        throw new Exception("[Err: " + errorResponse.errorCode + " : HTTP:" + errorResponse.httpCode + "]" + errorResponse.message);
+                    com.fasterxml.jackson.databind.JsonNode rootNode = objectMapper.readTree(responseBody);
+                    String resourceType = rootNode.has("resourceType") ? rootNode.get("resourceType").asText() : null;
+
+                    if ("Bundle".equals(resourceType)) {
+                        // Support format Bundle (mis. hasil endpoint lain / versi registry lain)
+                        Bundle bundle = fhirContext.newJsonParser().parseResource(Bundle.class, responseBody);
+                        for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
+                            if (entry.getResource() instanceof Consent) {
+                                consents.add((Consent) entry.getResource());
+                            }
+                        }
+                    } else if ("Consent".equals(resourceType)) {
+                        // Support format single resource Consent (bukan array/bundle)
+                        Consent consent = fhirContext.newJsonParser().parseResource(Consent.class, responseBody);
+                        consents.add(consent);
+                    } else {
+                        ErrorResponse errorResponse = objectMapper.treeToValue(rootNode, ErrorResponse.class);
+                        if (errorResponse.message != null) {
+                            throw new Exception("[Err: " + errorResponse.errorCode + " : HTTP:" + errorResponse.httpCode + "]" + errorResponse.message);
+                        }
                     }
                 } else if (responseBody.startsWith("[")) {
-                    Bundle bundle = fhirContext.newJsonParser().parseResource(
-                        Bundle.class, responseBody);
-
-                    for (Bundle.BundleEntryComponent entry : bundle.getEntry()) {
-                        if (entry.getResource() instanceof Consent) {
-                            consents.add((Consent) entry.getResource());
-                        }
+                    // Consent registry mengembalikan array JSON polos berisi resource Consent
+                    // (bukan FHIR Bundle), jadi setiap elemen di-parse satu per satu.
+                    com.fasterxml.jackson.databind.JsonNode arrayNode = objectMapper.readTree(responseBody);
+                    for (com.fasterxml.jackson.databind.JsonNode node : arrayNode) {
+                        Consent consent = fhirContext.newJsonParser().parseResource(Consent.class, node.toString());
+                        consents.add(consent);
                     }
                 }
             }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PolicyEvaluator.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PolicyEvaluator.java
@@ -49,8 +49,16 @@ public class PolicyEvaluator {
 
                 Consent.ConsentProvisionType decision = checkProvision(consent.getProvision(), theResource, action, 0, tmpIssues);
 
-                // AND-kan decision result antar Consent
-                result = provisionOperationAnd(result, decision);
+                // Consent yang tidak punya opini (NULL) diabaikan, bukan dipakai sebagai
+                // operand AND (kalau tidak, NULL akan selalu "membatalkan" DENY/PERMIT
+                // dari consent lain karena provisionOperationAnd() memperlakukan NULL
+                // sebagai annihilator, bukan identity).
+                if (decision == Consent.ConsentProvisionType.NULL)
+                    continue;
+
+                result = (result == Consent.ConsentProvisionType.NULL)
+                        ? decision
+                        : provisionOperationAnd(result, decision);
 
                 // karena menggunakan operation AND maka, 
                 // jika sudah jelas DENY maka tidak perlu lanjut cek Consent berikutnya

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PolicyEvaluator.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/PolicyEvaluator.java
@@ -1,0 +1,408 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.Procedure;
+import org.hl7.fhir.r4.model.Consent.ProvisionComponent;
+
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+
+import org.hl7.fhir.r4.model.DomainResource;
+
+public class PolicyEvaluator {
+    public final static int EVALUATION_SCOPE_ORGANIZATION = 0x01;
+    public final static int EVALUATION_SCOPE_PATIENT = 0x02;
+
+    private int evaluationScope;
+    private String patientId;
+    private List<Consent> consents;
+
+    public PolicyEvaluator(int evaluationScope, String patientId, List<Consent> consents) {
+        this.evaluationScope = evaluationScope;
+        this.patientId = patientId;
+        this.consents = consents;
+    }
+
+    public PolicyEvaluator(int evaluationScope, List<Consent> consents) {
+        this(evaluationScope, null, consents);
+    }
+
+    public void setPatientId(String patientId) {
+        this.patientId = patientId;
+    }
+
+    public ConsentOutcome evaluate(IBaseResource theResource, ActionEnum action, List<String> issues) {
+        Consent.ConsentProvisionType result = Consent.ConsentProvisionType.NULL;
+        ArrayList<String> tmpIssues = new ArrayList<String>();
+        if (consents != null && consents.size() > 0) {
+            for (Consent consent : consents) {
+                if (!isConsentValidInContext(consent, theResource))
+                    continue;
+
+                Consent.ConsentProvisionType decision = checkProvision(consent.getProvision(), theResource, action, 0, tmpIssues);
+
+                // AND-kan decision result antar Consent
+                result = provisionOperationAnd(result, decision);
+
+                // karena menggunakan operation AND maka, 
+                // jika sudah jelas DENY maka tidak perlu lanjut cek Consent berikutnya
+                if (result == Consent.ConsentProvisionType.DENY)
+                    break;
+            }
+        }
+
+        if (result == Consent.ConsentProvisionType.NULL)
+            return ConsentOutcome.PROCEED;
+        else if (result == Consent.ConsentProvisionType.DENY) {
+            issues.addAll(tmpIssues);
+            return ConsentOutcome.REJECT;
+        }
+
+        return ConsentOutcome.PROCEED;
+    }
+
+    private boolean isConsentValidInContext(Consent consent, IBaseResource theResource) {
+        if (consent.hasPatient()) {
+            // masih fokus di level organisasi
+            if ((evaluationScope & EVALUATION_SCOPE_PATIENT) != EVALUATION_SCOPE_PATIENT)
+                return false;
+            else {
+                // Pastikan consent yang memiliki id pasien sesuai dengan id pasien yang merequest
+                if (consent.hasPatient() && consent.getPatient().hasReference() && patientId != null) {
+                    if (!consent.getPatient().getReference().equals("Patient/" + patientId))
+                        return false;
+                }
+            }
+        }
+
+        if (!consent.hasProvision())
+            return false;
+        
+        // Check consent status
+        if (!consent.hasStatus() || 
+            consent.getStatus() != Consent.ConsentState.ACTIVE) {
+            return false;
+        }
+        
+        return true;
+    }
+
+    private Consent.ConsentProvisionType checkProvision(ProvisionComponent provision, IBaseResource theResource, ActionEnum action, int level, List<String> issues) {
+        Consent.ConsentProvisionType type = provision.getType();
+
+        // Exclude dari proces pengecekan provision
+        if (!isMatchProvisionRequirement(provision, theResource, action))
+            return Consent.ConsentProvisionType.NULL;
+
+        Consent.ConsentProvisionType secLabelProvision = checkSecurityLabelProvision(provision, theResource, level, issues);
+        if (secLabelProvision != Consent.ConsentProvisionType.NULL)
+            return secLabelProvision;
+
+        // cek sub-provision jika ada
+        if (provision.hasProvision()) {
+            Consent.ConsentProvisionType subResult = Consent.ConsentProvisionType.NULL;
+
+            ArrayList<String> subIssues = new ArrayList<String>();
+            for (ProvisionComponent subProvision : provision.getProvision()) {
+                Consent.ConsentProvisionType res = checkProvision(subProvision, theResource, action, level + 1, subIssues);
+                subResult = provisionOperationOr(subResult, res);
+            }
+
+            if (subResult == Consent.ConsentProvisionType.DENY) {
+                issues.addAll(subIssues);
+            }
+            // AND-kan subResult dengan parent type
+            type = provisionOperationAnd(type, subResult);
+        }
+
+        return type;
+    }
+
+    private boolean isMatchProvisionRequirement(ProvisionComponent provision, IBaseResource theResource, ActionEnum action) {
+        // provision.getActor() tidak perlu diperiksa, 
+        // karena di awal list consent sudah difilter berdasarkan actor sesuai organization ID
+
+        if (!provision.hasType())
+            return false;
+        
+        if (!isProvisionHasValidPeriodInContext(provision, theResource))
+            return false;
+
+        if (!isProvisionHasValidActionInContext(provision, action))
+            return false;
+
+        if (!isProvisionHasValidContentClassInContext(provision, theResource))
+            return false;
+        
+        if (!isProvisionHasValidContentCodeInContext(provision, theResource))
+            return false;
+
+        // Additional context checks can be added here
+        // e.g., purpose of use, user role, etc.
+
+        return true;
+    }
+
+    private boolean isProvisionHasValidPeriodInContext(ProvisionComponent provision, IBaseResource theResource) {
+        if (provision.hasPeriod()) {
+            Period period = provision.getPeriod();
+            Date now = new Date();
+            if (period.hasStart() && now.before(period.getStart())) {
+                return false;
+            }
+            if (period.hasEnd() && now.after(period.getEnd())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isProvisionHasValidActionInContext(ProvisionComponent provision, ActionEnum action) {
+        if (!provision.hasAction())
+            return false;
+
+        boolean actionOk = false;
+        for (CodeableConcept code : provision.getAction()) {
+            if (!code.hasCoding())
+                continue;
+            for (Coding coding: code.getCoding()) {
+                if (action.getConsentAction().equals(coding.getCode())) {
+                    actionOk = true;
+                    break;
+                }
+            }
+
+            if (actionOk)
+                break;
+        }
+        if (!actionOk)
+            return false;
+
+        return true;
+    }
+
+    private boolean isProvisionHasValidContentClassInContext(ProvisionComponent provision, IBaseResource theResource) {
+        if (provision.hasClass_()) {
+            boolean wantResourceType = false;
+            boolean matchResourceType = false;
+            for (Coding coding : provision.getClass_()) {
+                if (!coding.hasSystem() || !coding.hasCode())
+                    continue;
+                if (coding.getSystem().equals("http://hl7.org/fhir/resource-types")) {
+                    wantResourceType = true;
+                    if (coding.getCode().equals(theResource.fhirType())) {
+                        matchResourceType = true;
+                        break;
+                    }
+                }
+            }
+
+            if (wantResourceType && !matchResourceType)
+                return false;
+        }
+
+        return true;
+    }
+
+    private boolean isProvisionHasValidContentCodeInContext(ProvisionComponent provision, IBaseResource theResource) {
+        if (provision.hasCode()) {
+            boolean codingOk = false;
+            for (CodeableConcept code : provision.getCode()) {
+                if (!code.hasCoding())
+                    continue;
+
+                for (Coding coding : code.getCoding()) {
+                    if (theResource instanceof Observation) {
+                        Observation observation = (Observation) theResource;
+
+                        if (!observation.hasCode())
+                            continue;
+
+                        for (Coding codingObs : observation.getCode().getCoding()) {
+                            if (coding.getCode().equals(codingObs.getCode())) {
+                                codingOk = true;
+                                break;
+                            }
+                        }
+                    } else if (theResource instanceof Procedure) {
+                        Procedure procedure = (Procedure) theResource;
+                        
+                        if (!procedure.hasCode())
+                            continue;
+
+                        for (Coding codingObs : procedure.getCode().getCoding()) {
+                            if (coding.getCode().equals(codingObs.getCode())) {
+                                codingOk = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (codingOk)
+                        break;
+                }
+            }
+
+            if (!codingOk)
+                return false;
+        }
+
+        return true;
+    }
+
+    private Consent.ConsentProvisionType checkSecurityLabelProvision(ProvisionComponent provision, IBaseResource theResource, int level, List<String> issues) {
+        if (provision.hasSecurityLabel()) {
+            int evaluationScope = this.evaluationScope & EVALUATION_SCOPE_ORGANIZATION;
+            Consent.ConsentProvisionType type = provision.getType();
+            DomainResource targetResource = (DomainResource) theResource; // Cast to R4 DomainResource to access Meta methods
+            boolean provisionOk = false;
+            List<Coding> nonOrgCodings = new ArrayList<Coding>();
+
+            if (!targetResource.hasMeta() || !targetResource.getMeta().hasSecurity()) {
+                Consent.ConsentProvisionType negType = provisionOperationNeg(type);
+                if (negType == Consent.ConsentProvisionType.DENY) {
+                    issues.add("Resource " + theResource.fhirType() + " tidak memiliki Security Label");
+                }
+
+                return negType;
+            }
+
+            // Hanya berlaku di provision level-0
+            if (evaluationScope == EVALUATION_SCOPE_ORGANIZATION) {
+                for (Coding codingProvision : provision.getSecurityLabel()) {
+                    if (!codingProvision.hasCode() || !codingProvision.hasSystem())
+                        continue;
+
+                    if (codingProvision.getSystem().equals(Constants.ORGANIZATION_SECURITY_SYSTEM_NAME)) {
+                        // jika muncul security label organization di sub-provision maka, abaikan saja
+                        if (level > 0)
+                            continue;
+
+                        for (Coding codingResource : targetResource.getMeta().getSecurity()) {
+                            if (codingResource.getSystem().equals(Constants.ORGANIZATION_SECURITY_SYSTEM_NAME)
+                                && codingResource.hasCode()) {
+                                if (codingProvision.getCode().equals(codingResource.getCode())) {
+                                    provisionOk = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (provisionOk)
+                            break;
+                    }else {
+                        nonOrgCodings.add(codingProvision);
+                    }
+                }
+
+                if (!provisionOk) {
+                    Consent.ConsentProvisionType negType = provisionOperationNeg(type);
+                    if (negType == Consent.ConsentProvisionType.DENY) {
+                        issues.add("Resource " + theResource.fhirType() + " tidak dapat diakses oleh ID Organisasi anda");
+                    }
+
+                    return negType;
+                }
+            }else {
+                nonOrgCodings = provision.getSecurityLabel();
+            }
+
+            if (!nonOrgCodings.isEmpty()) {
+                provisionOk = false;
+                for (Coding codingProvision : nonOrgCodings) {
+                    for (Coding codingResource : targetResource.getMeta().getSecurity()) {
+                        if (!codingProvision.getSystem().equals(codingResource.getSystem()))
+                            continue;
+
+                        if (codingProvision.getSystem().equals("http://terminology.hl7.org/CodeSystem/v3-Confidentiality")) {
+                            if (isSecurityLabelAllowed(codingProvision.getCode(), codingResource.getCode())) {
+                                provisionOk = true;
+                                break;
+                            }
+                        } else if (codingProvision.getCode().equals(codingResource.getCode())) {
+                            provisionOk = true;
+                            break;
+                        }
+                    }
+
+                    if (provisionOk)
+                        break;
+                }
+
+                if (!provisionOk) {
+                    Consent.ConsentProvisionType negType = provisionOperationNeg(type);
+                    if (negType == Consent.ConsentProvisionType.DENY) {
+                        issues.add("Security Label di resource " + theResource.fhirType() + " tidak memenuhi persyaratan dari consent yang ditetapkan");
+                    }
+                    return negType;
+                }
+            }
+            // empty setelah semua security-label organization di-exclude, 
+            // maka dianggap sama dengan tidak punya security label
+            else if (level > 0)
+                return Consent.ConsentProvisionType.NULL;
+            
+            return type;
+        }
+
+        return Consent.ConsentProvisionType.NULL;
+    }
+
+    private boolean isSecurityLabelAllowed(String consentSecLabel, String resourceSecLabel) {
+        return securityLabelToInt(consentSecLabel) >= securityLabelToInt(resourceSecLabel);
+    }
+
+    private int securityLabelToInt(String secLabel) {
+        switch (secLabel) {
+            case "V":
+                return 4;
+            case "R":
+                return 3;
+            case "N":
+                return 2;
+            case "L":
+            default:
+                return 1;
+        }
+    }
+
+    public static Consent.ConsentProvisionType provisionOperationNeg(Consent.ConsentProvisionType provision) {
+        if (provision == Consent.ConsentProvisionType.PERMIT)
+            return Consent.ConsentProvisionType.DENY;
+        else if (provision == Consent.ConsentProvisionType.DENY)
+            return Consent.ConsentProvisionType.PERMIT;
+
+        return Consent.ConsentProvisionType.NULL;
+    }
+
+    public static Consent.ConsentProvisionType provisionOperationOr(Consent.ConsentProvisionType provision1, Consent.ConsentProvisionType provision2) {
+        if (provision1 == Consent.ConsentProvisionType.NULL)
+            return provision2;
+        else if (provision2 == Consent.ConsentProvisionType.NULL)
+            return provision1;
+        else if (provision1 == Consent.ConsentProvisionType.PERMIT || provision2 == Consent.ConsentProvisionType.PERMIT)
+            return Consent.ConsentProvisionType.PERMIT;
+        else if (provision1 == Consent.ConsentProvisionType.NULL && provision2 == Consent.ConsentProvisionType.NULL)
+            return Consent.ConsentProvisionType.NULL;
+
+        return Consent.ConsentProvisionType.DENY;
+    }
+
+    public static Consent.ConsentProvisionType provisionOperationAnd(Consent.ConsentProvisionType provision1, Consent.ConsentProvisionType provision2) {
+        if (provision1 == Consent.ConsentProvisionType.NULL || provision2 == Consent.ConsentProvisionType.NULL)
+            return Consent.ConsentProvisionType.NULL;
+        else if (provision1 == Consent.ConsentProvisionType.PERMIT && provision2 == Consent.ConsentProvisionType.PERMIT)
+            return Consent.ConsentProvisionType.PERMIT;
+
+        return Consent.ConsentProvisionType.DENY;
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ResourceManipulationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ResourceManipulationInterceptor.java
@@ -1,0 +1,788 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
+import ca.uhn.fhir.jpa.searchparam.SearchParameterMap;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.CarePlan;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.EpisodeOfCare;
+import org.hl7.fhir.r4.model.Goal;
+import org.hl7.fhir.r4.model.Medication;
+import org.hl7.fhir.r4.model.MedicationDispense;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.hl7.fhir.r4.model.Specimen;
+import org.hl7.fhir.r4.model.Substance;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationConstants;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOperationStatusEnum;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+
+@Interceptor(order = AuthorizationConstants.ORDER_AUTH_INTERCEPTOR + 50)
+public class ResourceManipulationInterceptor {
+    @Autowired
+    private DaoRegistry resourceDaoRegistry;
+
+    @Autowired
+    private ConsentProperties consentProperties;
+
+    private LoaderWithCache loader;
+
+    private boolean isAdminAccess = false;
+
+    public ResourceManipulationInterceptor() {
+        loader = new LoaderWithCache(consentProperties);
+        loader.setResourceDaoRegistry(resourceDaoRegistry);
+    }
+
+    @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)
+    public void insertResource(IBaseResource theResource, RequestDetails theRequestDetails) {
+        checkIfAdminAccess(theRequestDetails);
+
+        Class<?> resourceClass = theResource.getClass();
+        String patientId = Utils.getPatientId(theResource);
+        String userOrgId = theRequestDetails.getHeader(consentProperties.getOrganizationRequestHeader());
+        boolean skipEvaluation = isAdminAccess;
+        if (theResource instanceof Encounter) {
+            checkEncounterServiceProvider(theResource, userOrgId);
+
+            addSecurityLabelForOrganization(theResource, userOrgId);
+
+            // Cek apakah theResource.episodeOfCare tersedia
+            // Jika ya, maka load resource EpisodeOfCare tersebut dan tambahkan userOrgId sebagai salah satu CareTeam (pastikan tidak duplikat)
+            // CareTeam digunakan untuk menentukan apakah Faskes boleh mengakses Encounter dan Resource yang terkait encounter yang memiliki EpisodeOfCare yang sama
+            addCareTeamToEpisodeOfCare((Encounter) theResource, userOrgId, theRequestDetails);
+        } else if (theResource instanceof EpisodeOfCare) {
+            checkManagingOrganizationCreate(theResource, theRequestDetails);
+        } else if (consentProperties.getFhirResourceHasEncounter().contains(resourceClass)) {
+            String encounterId = Utils.getEncounterId(theResource);
+            if (encounterId != null) {
+                Encounter encounter = loader.getResource(encounterId, Encounter.class, theRequestDetails);
+                if (encounter != null) {
+                    copySecurityLabel(encounter, theResource);
+
+                    if (theResource instanceof ServiceRequest) {
+                        // Cek apakah theResource.basedOn bertipe ServiceRequest tersedia
+                        // Jika ya, cek apakah ServiceRequest.requester berasal dari Organization yang berbeda
+                        // Dan jika ya, tambahkan security label organization requester ke theResource
+                        handleServiceRequestBasedOnAnotherServiceRequest((ServiceRequest) theResource, theRequestDetails, userOrgId);
+
+                        // Cek apakah theResource.requester berasal dari Organization yang berbeda
+                        // Jika ya, tambahkan security label organization requester ke theResource. Pastikan security label tidak duplikat
+                        handleServiceRequestRequester((ServiceRequest) theResource, userOrgId);
+                    }
+                } else {
+                    throw new UnprocessableEntityException(theResource.fhirType() + ".encounter resource wajib diisi",
+                        createForbiddenOperationOutcome(theResource.fhirType() + ".encounter is required"));
+                }
+            } else {
+                // Jika encounter tidak ditemukan minimal security label Organisasi ditambahkan
+                addSecurityLabelForOrganization(theResource, userOrgId);
+            }
+        } else if (Constants.FHIR_RESOURCE_CONFORMANNCE.contains(resourceClass)
+                || Constants.FHIR_RESOURCE_TERMINOLOGY.contains(resourceClass)
+                || Constants.FHIR_RESOURCE_CLINICAL_REASONING.contains(resourceClass)) {
+            if (!isAdminAccess) {
+                throw toForbiddenOperationException("Anda hanya diperbolehkan membuat resource " + theResource.fhirType(),
+                    createForbiddenOperationOutcome("You are only allowed to create resource " + theResource.fhirType()));
+            }
+        } else {
+            boolean addSecLabel = false;
+            String encounterId = getEncounterIdIndirect(theResource, theRequestDetails);
+            if (encounterId != null) {
+                Encounter encounter = loader.getResource(encounterId, Encounter.class, theRequestDetails);
+                if (encounter != null) {
+                    copySecurityLabel(encounter, theResource);
+                    addSecLabel = true;
+                }
+            }
+
+            if (!addSecLabel)
+                addSecurityLabelForOrganization(theResource, userOrgId);
+        }
+
+        if (!skipEvaluation)
+            applyPolicyEvaluation(userOrgId, patientId, ActionEnum.CREATE, theResource);
+    }
+
+    @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
+    public void updateResource(IBaseResource theOldResource, IBaseResource theNewResource, RequestDetails theRequestDetails) {
+        checkIfAdminAccess(theRequestDetails);
+
+        Class<?> resourceClass = theNewResource.getClass();
+        String patientId = Utils.getPatientId(theNewResource);
+        String userOrgId = theRequestDetails.getHeader(consentProperties.getOrganizationRequestHeader());
+        boolean skipEvaluation = isAdminAccess;
+        if (theNewResource instanceof Encounter) {
+            checkEncounterServiceProvider(theNewResource, userOrgId);
+
+            Encounter encNew = (Encounter) theNewResource;
+            Encounter encOld = (Encounter) theOldResource;
+
+            // update episode of care terlambat
+            if (!encOld.hasEpisodeOfCare() && encNew.hasEpisodeOfCare()) {
+                addCareTeamToEpisodeOfCare(encNew, userOrgId, theRequestDetails);
+            }
+        }else if (theNewResource instanceof EpisodeOfCare) {
+            // Tolak perubahan ManagingOrganization waktu update
+            checkManagingOrganizationUpdate(theOldResource, theNewResource, theRequestDetails);
+
+            // Tolak perubahan EpisodeOfCare.team dari request client, tapi perbolehkan jika penambahan dilakukan secara internal (didalam interceptor ini)
+            checkCareTeamModification(theOldResource, theNewResource, theRequestDetails);
+        } else if (Constants.FHIR_RESOURCE_CONFORMANNCE.contains(resourceClass)
+                || Constants.FHIR_RESOURCE_TERMINOLOGY.contains(resourceClass)
+                || Constants.FHIR_RESOURCE_CLINICAL_REASONING.contains(resourceClass)) {
+            if (!isAdminAccess) {
+                throw toForbiddenOperationException("Anda hanya diperbolehkan mengubah resource " + theNewResource.fhirType(),
+                    createForbiddenOperationOutcome("You are only allowed to update resource " + theNewResource.fhirType()));
+            }
+        }
+     
+        if (!skipEvaluation)
+            applyPolicyEvaluation(userOrgId, patientId, ActionEnum.UPDATE, theNewResource);
+    }
+
+    @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_DELETED)
+    public void deleteResource(IBaseResource theResource, RequestDetails theRequestDetails) {
+        checkIfAdminAccess(theRequestDetails);
+
+        Class<?> resourceClass = theResource.getClass();
+        String patientId = Utils.getPatientId(theResource);
+        String userOrgId = theRequestDetails.getHeader(consentProperties.getOrganizationRequestHeader());
+        boolean skipEvaluation = isAdminAccess;
+        if (Constants.FHIR_RESOURCE_CONFORMANNCE.contains(resourceClass)
+                || Constants.FHIR_RESOURCE_TERMINOLOGY.contains(resourceClass)
+                || Constants.FHIR_RESOURCE_CLINICAL_REASONING.contains(resourceClass)) {
+            if (!isAdminAccess) {
+                throw toForbiddenOperationException("Anda hanya diperbolehkan menghapus resource " + theResource.fhirType(),
+                    createForbiddenOperationOutcome("You are only allowed to delete resource " + theResource.fhirType()));
+            }
+        }
+
+        if (!skipEvaluation)
+            applyPolicyEvaluation(userOrgId, patientId, ActionEnum.DELETE, theResource);
+    }
+
+    private void checkIfAdminAccess(RequestDetails theRequestDetails) {
+        // DANGER!!!
+        // Pastikan frontend service menghapus ADMINISTRATOR_REQUEST_HEADER agar tidak disalahgunakan
+        String addmin = theRequestDetails.getHeader(consentProperties.getAdministratorRequestHeader());
+        isAdminAccess = "ADMIN".equals(addmin);
+    }
+
+    private void checkEncounterServiceProvider(IBaseResource theResource, String userOrgId) {
+        Encounter encounter = (Encounter) theResource;
+        if (encounter.hasServiceProvider()) {
+            String serviceProviderRef = encounter.getServiceProvider().getReference();
+            
+            // jika berasal dari admin (contoh; karena proses copy dari SATUSEHAT) biarkan saja apa adanya
+            if (!isAdminAccess && !serviceProviderRef.equals("Organization/" + userOrgId)) {
+                throw toForbiddenOperationException("Anda hanya diperbolehkan membuat Encounter untuk organisasi Anda sendiri.",
+                    createForbiddenOperationOutcome("You are only allowed to create Encounter.serviceProvider for your own organization"));
+            }
+        } else {
+            throw new UnprocessableEntityException("Field serviceProvider wajib diisi.", 
+                createForbiddenOperationOutcome("Encounter.serviceProvider is required"));
+        }
+    }
+
+    private void copySecurityLabel(Encounter enc, IBaseResource theResource) {
+        if (enc == null || theResource == null) {
+            return;
+        }
+
+        if (!enc.hasMeta() || !enc.getMeta().hasSecurity()) {
+            return;
+        }
+
+        DomainResource targetResource = (DomainResource) theResource;
+        Meta targetMeta = targetResource.getMeta();
+        if (targetMeta == null) {
+            targetMeta = new Meta();
+            targetResource.setMeta(targetMeta);
+        }
+
+        // Copy security labels from Encounter to target resource without duplicates
+        for (Coding sourceSecurity : enc.getMeta().getSecurity()) {
+            boolean exists = false;
+
+            // Check if this security label already exists in the target resource
+            if (targetMeta.hasSecurity()) {
+                for (Coding targetSecurity : targetMeta.getSecurity()) {
+                    if (isSecurityLabelEqual(sourceSecurity, targetSecurity)) {
+                        exists = true;
+                        break;
+                    }
+                }
+            }
+
+            // Add only if it doesn't already exist (avoid duplicates)
+            if (!exists) {
+                Coding newSecurity = sourceSecurity.copy();
+                targetMeta.addSecurity(newSecurity);
+            }
+        }
+    }
+
+    /**
+     * Add security label for an organization to a resource
+     */
+    private void addSecurityLabelForOrganization(IBaseResource theResource, String orgId) {
+        if (theResource == null || orgId == null) {
+            return;
+        }
+
+        // Cast to R4 DomainResource to access Meta methods
+        DomainResource targetResource = (DomainResource) theResource;
+
+        // Get or create Meta for the target resource
+        Meta targetMeta = targetResource.getMeta();
+        if (targetMeta == null) {
+            targetMeta = new Meta();
+            targetResource.setMeta(targetMeta);
+        }
+
+        // Create new security label
+        Coding newSecurity = new Coding();
+        newSecurity.setSystem(consentProperties.getOrganizationSecuritySystemName());
+        newSecurity.setCode(orgId);
+
+        // Check if this security label already exists
+        boolean exists = false;
+        if (targetMeta.hasSecurity()) {
+            for (Coding existingSecurity : targetMeta.getSecurity()) {
+                if (isSecurityLabelEqual(newSecurity, existingSecurity)) {
+                    exists = true;
+                    break;
+                }
+            }
+        }
+
+        // Add only if it doesn't already exist (avoid duplicates)
+        if (!exists) {
+            targetMeta.addSecurity(newSecurity);
+        }
+    }
+
+    /**
+     * Check if two security labels are equal by comparing system and code
+     */
+    private boolean isSecurityLabelEqual(Coding security1, Coding security2) {
+        if (security1 == null || security2 == null) {
+            return false;
+        }
+
+        boolean systemEqual = (security1.getSystem() == null && security2.getSystem() == null)
+                || (security1.getSystem() != null && security1.getSystem().equals(security2.getSystem()));
+
+        boolean codeEqual = (security1.getCode() == null && security2.getCode() == null)
+                || (security1.getCode() != null && security1.getCode().equals(security2.getCode()));
+
+        return systemEqual && codeEqual;
+    }
+
+    /**
+     * Handle ServiceRequest basedOn references - check for requester from different organizations
+     * and add security labels accordingly
+     */
+    private void handleServiceRequestBasedOnAnotherServiceRequest(ServiceRequest serviceRequest, RequestDetails theRequestDetails, String userOrgId) {
+        if (serviceRequest == null || !serviceRequest.hasBasedOn()) {
+            return;
+        }
+
+        // Process each basedOn reference
+        for (Reference basedOnRef : serviceRequest.getBasedOn()) {
+            if (!basedOnRef.hasReference() || !basedOnRef.getReference().startsWith("ServiceRequest/")) {
+                continue;
+            }
+
+            // Extract ServiceRequest ID
+            String serviceRequestId = basedOnRef.getReference().substring("ServiceRequest/".length());
+            if (serviceRequestId == null || serviceRequestId.isEmpty()) {
+                continue;
+            }
+
+            // Load the referenced ServiceRequest
+            ServiceRequest basedOnServiceRequest = loader.getResource(serviceRequestId, ServiceRequest.class, theRequestDetails);
+            if (basedOnServiceRequest == null) {
+                continue;
+            }
+
+            // Check if the basedOn ServiceRequest has a requester from a different organization
+            if (basedOnServiceRequest.hasRequester() && basedOnServiceRequest.getRequester().hasReference()) {
+                String requesterRef = basedOnServiceRequest.getRequester().getReference();
+
+                // Check if requester is an Organization
+                if (requesterRef.startsWith("Organization/")) {
+                    String requesterOrgId = requesterRef.substring("Organization/".length());
+
+                    // Check if requester organization is different from encounter's organization
+                    // and different from current user's organization
+                    if (!requesterOrgId.equals(userOrgId)) {
+                        // Add security label for the requester's organization
+                        addSecurityLabelForOrganization(serviceRequest, requesterOrgId);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Handle ServiceRequest requester - check if requester is from a different organization
+     * and add security label accordingly
+     */
+    private void handleServiceRequestRequester(ServiceRequest serviceRequest, String userOrgId) {
+        if (serviceRequest == null || !serviceRequest.hasRequester()) {
+            return;
+        }
+
+        // Get requester reference
+        Reference requesterRef = serviceRequest.getRequester();
+        if (!requesterRef.hasReference()) {
+            return;
+        }
+
+        // Check if requester is an Organization
+        if (requesterRef.getReference().startsWith("Organization/")) {
+            String requesterOrgId = requesterRef.getReference().substring("Organization/".length());
+
+            // Check if requester organization is different from current user's organization
+            if (!requesterOrgId.equals(userOrgId)) {
+                // Add security label for the requester's organization
+                addSecurityLabelForOrganization(serviceRequest, requesterOrgId);
+            }
+        }
+    }
+
+    /**
+     * Check if Encounter has episodeOfCare references and add user's organization to CareTeam
+     * without duplicates
+     */
+    private void addCareTeamToEpisodeOfCare(Encounter encounter, String userOrgId, RequestDetails theRequestDetails) {
+        if (encounter == null || !encounter.hasEpisodeOfCare()) {
+            return;
+        }
+
+        // Process each episodeOfCare reference
+        for (Reference eocRef : encounter.getEpisodeOfCare()) {
+            if (!eocRef.hasReference() || !eocRef.getReference().startsWith("EpisodeOfCare/")) {
+                continue;
+            }
+
+            // Extract EpisodeOfCare ID
+            String eocId = eocRef.getReference().substring("EpisodeOfCare/".length());
+            if (eocId == null || eocId.isEmpty()) {
+                continue;
+            }
+
+            // Load the EpisodeOfCare
+            EpisodeOfCare episodeOfCare = loader.getResource(eocId, EpisodeOfCare.class, theRequestDetails);
+            if (episodeOfCare == null) {
+                continue;
+            }
+
+            // Add user's organization to CareTeam without duplicates
+            addOrganizationToCareTeam(episodeOfCare, userOrgId, theRequestDetails);
+        }
+    }
+
+    /**
+     * Add organization to CareTeam without duplicates
+     */
+    private void addOrganizationToCareTeam(EpisodeOfCare episodeOfCare, String userOrgId, RequestDetails theRequestDetails) {
+        if (episodeOfCare == null || userOrgId == null) {
+            return;
+        }
+
+        // Create new CareTeam member reference for the organization
+        Reference newParticipant = new Reference("Organization/" + userOrgId);
+
+        // Check if this organization already exists in CareTeam
+        boolean exists = false;
+        if (episodeOfCare.hasTeam()) {
+            for (Reference existingParticipant : episodeOfCare.getTeam()) {
+                if (existingParticipant.hasReference()) {
+                    String existingRef = existingParticipant.getReference();
+                    if (existingRef.equals("Organization/" + userOrgId)) {
+                        exists = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Add only if it doesn't already exist (avoid duplicates)
+        if (!exists) {
+            // Tandai modifikasi internal
+            Map<Object, Object> userData = theRequestDetails.getUserData();
+            userData.put("internal-careteam-modification", true);
+
+            episodeOfCare.addTeam(newParticipant);
+        }
+    }
+
+    private void checkManagingOrganizationCreate(IBaseResource theResource, RequestDetails theRequestDetails) {
+        String userOrgId = theRequestDetails.getHeader(consentProperties.getOrganizationRequestHeader());
+        EpisodeOfCare eoc = (EpisodeOfCare) theResource;
+
+        if (eoc.hasManagingOrganization()) {
+            String serviceProviderRef = eoc.getManagingOrganization().getReference();
+            String orgId = serviceProviderRef.substring("Organization/".length());
+
+            // Hanya boleh pakai organization ID sendiri atau KEMENKES untuk  managingOrganization
+            if (!orgId.equals(consentProperties.getOrganizationManagingIdKemenkes()) && !orgId.equals(userOrgId)) {
+                throw toForbiddenOperationException("Anda hanya diperbolehkan membuat EpisodeOfCare untuk organisasi Anda sendiri.",
+                    createForbiddenOperationOutcome("You are only allowed to create EpisodeOfCare for your own organization"));
+            }
+        } else {
+            throw new UnprocessableEntityException("EpisodeOfCare.managingOrganization wajib diisi.",
+                    createForbiddenOperationOutcome("EpisodeOfCare.managingOrganization is required"));
+        }
+    }
+
+    private void checkManagingOrganizationUpdate(IBaseResource theOldResource, IBaseResource theNewResource, RequestDetails theRequestDetails) {
+        String userOrgId = theRequestDetails.getHeader(consentProperties.getOrganizationRequestHeader());
+        EpisodeOfCare eocNew = (EpisodeOfCare) theNewResource;
+        EpisodeOfCare eocOld = (EpisodeOfCare) theOldResource;
+
+        if (!eocNew.hasManagingOrganization() && eocOld.hasManagingOrganization()) {
+            throw toForbiddenOperationException("Tidak diperbolehkan menghapus managingOrtanization.",
+                    createForbiddenOperationOutcome("Not allowed to delete EpisodeOfCare.managingOrganization"));
+        } else if (eocNew.getManagingOrganization().hasReference()
+            && eocOld.getManagingOrganization().hasReference()
+            && !eocNew.getManagingOrganization().getReference().equals(eocOld.getManagingOrganization().getReference())
+            && !eocNew.getManagingOrganization().getReference().equals("Organization/" + userOrgId)) {
+            throw toForbiddenOperationException("Tidak diperbolehkan mengganti managingOrtanization ke Faskes lain.",
+                    createForbiddenOperationOutcome("Not allowed to change EpisodeOfCare.managingOrganization to another facility"));
+        }
+    }
+
+    /**
+     * Check if EpisodeOfCare.team has been modified by client request
+     * Reject client-side changes to team field, but allow internal additions
+     */
+    private void checkCareTeamModification(IBaseResource theOldResource, IBaseResource theNewResource, RequestDetails theRequestDetails) {
+        EpisodeOfCare eocOld = (EpisodeOfCare) theOldResource;
+        EpisodeOfCare eocNew = (EpisodeOfCare) theNewResource;
+
+        // Check if team field has been modified
+        boolean teamModified = false;
+        
+        // Check if team list sizes are different
+        if ((eocOld.getTeam() == null && eocNew.getTeam() != null) ||
+            (eocOld.getTeam() != null && eocNew.getTeam() == null) ||
+            (eocOld.getTeam() != null && eocNew.getTeam() != null &&
+             eocOld.getTeam().size() != eocNew.getTeam().size())) {
+            teamModified = true;
+        } else if (eocOld.getTeam() != null && eocNew.getTeam() != null) {
+            // Check if team members are different
+            for (Reference oldMember : eocOld.getTeam()) {
+                boolean found = false;
+                for (Reference newMember : eocNew.getTeam()) {
+                    if (oldMember.equalsDeep(newMember)) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    teamModified = true;
+                    break;
+                }
+            }
+        }
+
+        // If team has been modified and it's not an internal operation, reject it
+        if (teamModified && !isInternalCareTeamModification(theRequestDetails)) {
+            throw toForbiddenOperationException("Tidak diperbolehkan mengubah EpisodeOfCare.team dari request client.",
+                    createForbiddenOperationOutcome("Not allowed to modify EpisodeOfCare.team from client request"));
+        }
+    }
+
+    /**
+     * Check if the current operation is an internal CareTeam modification
+     * (done by the interceptor, not by client request)
+     */
+    private boolean isInternalCareTeamModification(RequestDetails theRequestDetails) {
+        // Check if there's a flag indicating internal modification
+        Map<Object, Object> userData = theRequestDetails.getUserData();
+        Object internalFlag = userData.get("internal-careteam-modification");
+        return internalFlag != null && Boolean.TRUE.equals(internalFlag);
+    }
+
+    public String getEncounterIdIndirect(IBaseResource theResource, RequestDetails theRequestDetails) {
+        if (theResource == null) {
+            return null;
+        }
+
+        // Composition
+        if (theResource instanceof Goal) {
+            // Load CarePlan.goal yang merefer ke id theResource, lalu panggil return Utils.getEncounterId(careplan)
+            return getEncounterIdFromGoal((Goal) theResource, theRequestDetails);
+        } else if (theResource instanceof Specimen) {
+            // Get ServiceRequest dari Specimen.request lalu panggil return Utils.getEncounterId(serviceRequest)
+            return getEncounterIdFromSpecimen((Specimen) theResource, theRequestDetails);
+        } else if (theResource instanceof Medication) {
+            // Cari dari referensi MedicationRequest.medicationReference atau MedicationDispense.medicationReference 
+            // atau MedicationStatement.medicationReference atau MedicationAdministration.medicationReference
+            // Berhenti mencari jika pertama ditemukan dan panggil return Utils.getEncounterId(resourceFound)
+            return getEncounterIdFromMedication((Medication) theResource, theRequestDetails);
+        } else if (theResource instanceof Substance) {
+            // Cari dari referensi Specimen.processing.additive lalu panggil return Utils.getEncounterId(specimen)
+            // NOTE: FHIR tidak bisa melakukan query secara langsung processing.additive dari specimen.
+            //      Untuk sementara karena batasan ini, Substance dimasukkan sebagai WHITELIST
+            // return getEncounterIdFromSubstance((Substance) theResource, theRequestDetails);
+        }
+
+        return null;
+    }
+
+    /**
+     * Get Encounter ID from Goal by finding the CarePlan that references this Goal
+     */
+    private String getEncounterIdFromGoal(Goal goal, RequestDetails theRequestDetails) {
+        if (goal == null || !goal.hasIdElement() || !goal.getIdElement().hasIdPart()) {
+            return null;
+        }
+
+        String goalId = goal.getIdElement().getIdPart();
+        
+        // Search for CarePlan that has a goal reference to this Goal
+        IFhirResourceDao<CarePlan> carePlanDao = (IFhirResourceDao<CarePlan>) resourceDaoRegistry.getResourceDao(CarePlan.class);
+        
+        try {
+            // Create search parameter map for goal reference
+            SearchParameterMap paramMap = new SearchParameterMap();
+            paramMap.add(CarePlan.SP_GOAL, new ReferenceParam("Goal/" + goalId));
+            paramMap.setCount(1);
+            
+            IBundleProvider bundleProvider = carePlanDao.search(paramMap, theRequestDetails);
+            
+            if (bundleProvider != null && bundleProvider.size() > 0) {
+                // Get the first CarePlan
+                List<IBaseResource> resources = bundleProvider.getResources(0, 1);
+                if (!resources.isEmpty() && resources.get(0) instanceof CarePlan) {
+                    CarePlan carePlan = (CarePlan) resources.get(0);
+                    return Utils.getEncounterId(carePlan);
+                }
+            }
+        } catch (Exception e) {}
+        
+        return null;
+    }
+
+    /**
+     * Get Encounter ID from Specimen by following the ServiceRequest reference
+     */
+    private String getEncounterIdFromSpecimen(Specimen specimen, RequestDetails theRequestDetails) {
+        if (specimen == null || !specimen.hasRequest()) {
+            return null;
+        }
+
+        // Get the first ServiceRequest reference from Specimen.request
+        for (Reference requestRef : specimen.getRequest()) {
+            if (!requestRef.hasReference() || !requestRef.getReference().startsWith("ServiceRequest/")) {
+                continue;
+            }
+
+            String serviceRequestId = requestRef.getReference().substring("ServiceRequest/".length());
+            if (serviceRequestId == null || serviceRequestId.isEmpty()) {
+                continue;
+            }
+
+            // Load the ServiceRequest
+            ServiceRequest serviceRequest = loader.getResource(serviceRequestId, ServiceRequest.class, theRequestDetails);
+            if (serviceRequest != null) {
+                return Utils.getEncounterId(serviceRequest);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get Encounter ID from Medication by searching for resources that reference this Medication
+     */
+    private String getEncounterIdFromMedication(Medication medication, RequestDetails theRequestDetails) {
+        if (medication == null || !medication.hasIdElement() || !medication.getIdElement().hasIdPart()) {
+            return null;
+        }
+
+        String medicationId = medication.getIdElement().getIdPart();
+        String medicationReference = "Medication/" + medicationId;
+
+        // Search in order: MedicationRequest, MedicationDispense, MedicationStatement, MedicationAdministration
+        // Stop when first found
+        
+        // 1. Try MedicationRequest
+        IFhirResourceDao<MedicationRequest> medRequestDao = (IFhirResourceDao<MedicationRequest>) resourceDaoRegistry.getResourceDao(MedicationRequest.class);
+        try {
+            SearchParameterMap paramMap = new SearchParameterMap();
+            paramMap.add(MedicationRequest.SP_MEDICATION, new ReferenceParam(medicationReference));
+            paramMap.setCount(1);
+            
+            IBundleProvider bundleProvider = medRequestDao.search(paramMap, theRequestDetails);
+            
+            if (bundleProvider != null && bundleProvider.size() > 0) {
+                List<IBaseResource> resources = bundleProvider.getResources(0, 1);
+                if (!resources.isEmpty() && resources.get(0) instanceof MedicationRequest) {
+                    MedicationRequest medRequest = (MedicationRequest) resources.get(0);
+                    String encounterId = Utils.getEncounterId(medRequest);
+                    if (encounterId != null) {
+                        return encounterId;
+                    }
+                }
+            }
+        } catch (Exception e) {}
+
+        // 2. Try MedicationDispense
+        IFhirResourceDao<MedicationDispense> medDispenseDao = (IFhirResourceDao<MedicationDispense>) resourceDaoRegistry.getResourceDao(MedicationDispense.class);
+        try {
+            SearchParameterMap paramMap = new SearchParameterMap();
+            paramMap.add(MedicationDispense.SP_MEDICATION, new ReferenceParam(medicationReference));
+            paramMap.setCount(1);
+            
+            IBundleProvider bundleProvider = medDispenseDao.search(paramMap, theRequestDetails);
+            
+            if (bundleProvider != null && bundleProvider.size() > 0) {
+                List<IBaseResource> resources = bundleProvider.getResources(0, 1);
+                if (!resources.isEmpty() && resources.get(0) instanceof MedicationDispense) {
+                    MedicationDispense medDispense = (MedicationDispense) resources.get(0);
+                    String encounterId = Utils.getEncounterId(medDispense);
+                    if (encounterId != null) {
+                        return encounterId;
+                    }
+                }
+            }
+        } catch (Exception e) {}
+
+        // SKIP dulu Try 3 dan 4, untuk kurangi beban proses
+        // 3. Try MedicationStatement
+        /*IFhirResourceDao<MedicationStatement> medStatementDao = (IFhirResourceDao<MedicationStatement>) resourceDaoRegistry.getResourceDao(MedicationStatement.class);
+        try {
+            SearchParameterMap paramMap = new SearchParameterMap();
+            paramMap.add(MedicationStatement.SP_MEDICATION, new ReferenceParam(medicationReference));
+            paramMap.setCount(1);
+            
+            IBundleProvider bundleProvider = medStatementDao.search(paramMap, theRequestDetails);
+            
+            if (bundleProvider != null && bundleProvider.size() > 0) {
+                List<IBaseResource> resources = bundleProvider.getResources(0, 1);
+                if (!resources.isEmpty() && resources.get(0) instanceof MedicationStatement) {
+                    MedicationStatement medStatement = (MedicationStatement) resources.get(0);
+                    String encounterId = Utils.getEncounterId(medStatement);
+                    if (encounterId != null) {
+                        return encounterId;
+                    }
+                }
+            }
+        } catch (Exception e) {}
+
+        // 4. Try MedicationAdministration
+        IFhirResourceDao<MedicationAdministration> medAdminDao = (IFhirResourceDao<MedicationAdministration>) resourceDaoRegistry.getResourceDao(MedicationAdministration.class);
+        try {
+            SearchParameterMap paramMap = new SearchParameterMap();
+            paramMap.add(MedicationAdministration.SP_MEDICATION, new ReferenceParam(medicationReference));
+            paramMap.setCount(1);
+            
+            IBundleProvider bundleProvider = medAdminDao.search(paramMap, theRequestDetails);
+            
+            if (bundleProvider != null && bundleProvider.size() > 0) {
+                List<IBaseResource> resources = bundleProvider.getResources(0, 1);
+                if (!resources.isEmpty() && resources.get(0) instanceof MedicationAdministration) {
+                    MedicationAdministration medAdmin = (MedicationAdministration) resources.get(0);
+                    String encounterId = Utils.getEncounterId(medAdmin);
+                    if (encounterId != null) {
+                        return encounterId;
+                    }
+                }
+            }
+        } catch (Exception e) {}*/
+
+        return null;
+    }
+
+    private void applyPolicyEvaluation(String userOrgId, String patientId, ActionEnum action, IBaseResource theResource) {
+        if (!isAdminAccess) {
+            // load daftar consent berdasarkan Organisasi
+            PolicyEvaluator policyEvaluator = new PolicyEvaluator(PolicyEvaluator.EVALUATION_SCOPE_ORGANIZATION, patientId, loader.getConsentList(consentProperties.getEnvironment(), userOrgId));
+            
+            // evaluasi action CREATE
+            ArrayList<String> issues = new ArrayList<String>();
+            ConsentOutcome outcome = policyEvaluator.evaluate(theResource, action, issues);
+
+            if (outcome.getStatus() == ConsentOperationStatusEnum.REJECT) {
+                // Get resource type name
+                String resourceType = theResource.fhirType();
+                String message;
+                switch (action) {
+                    case CREATE:
+                        message = "You are not allowed to create " + resourceType + " resource based on consent policy.";
+                        break;
+                    case UPDATE:
+                        message = "You are not allowed to update " + resourceType + " resource based on consent policy.";
+                        break;
+                    case DELETE:
+                        message = "You are not allowed to delete " + resourceType + " resource based on consent policy.";
+                        break;
+                    default:
+                        message = "You are not allowed to " + action + " " + resourceType + " resource based on consent policy.";
+                        message = "Anda tidak diperbolehkan melakukan aksi ini pada resource " + resourceType + " berdasarkan kebijakan consent.";
+                        break;
+                }
+                
+                throw toForbiddenOperationException(message, createForbiddenOperationOutcome(issues));
+            }
+        }
+    }
+
+    private static ForbiddenOperationException toForbiddenOperationException(String message, IBaseOperationOutcome operationOutcome) {
+		return new ForbiddenOperationException(message, operationOutcome);
+	}
+
+    /**
+     * Create an OperationOutcome with issue details for forbidden operations
+     */
+    private static OperationOutcome createForbiddenOperationOutcome(String diagnostics) {
+        OperationOutcome operationOutcome = new OperationOutcome();
+        OperationOutcome.OperationOutcomeIssueComponent issue = operationOutcome.addIssue();
+        issue.setSeverity(OperationOutcome.IssueSeverity.ERROR);
+        issue.setCode(OperationOutcome.IssueType.FORBIDDEN);
+        issue.setDiagnostics(diagnostics);
+
+        return operationOutcome;
+    }
+
+    private static OperationOutcome createForbiddenOperationOutcome(List<String> diagnostics) {
+        OperationOutcome operationOutcome = new OperationOutcome();
+
+        for (String diagnostic : diagnostics) {
+            OperationOutcome.OperationOutcomeIssueComponent issue = operationOutcome.addIssue();
+            issue.setSeverity(OperationOutcome.IssueSeverity.ERROR);
+            issue.setCode(OperationOutcome.IssueType.FORBIDDEN);
+            issue.setDiagnostics(diagnostic);
+        }
+
+        return operationOutcome;
+    }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ResourceManipulationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/ResourceManipulationInterceptor.java
@@ -27,9 +27,10 @@ import org.hl7.fhir.r4.model.ServiceRequest;
 import org.hl7.fhir.r4.model.Specimen;
 import org.hl7.fhir.r4.model.Substance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
-import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
@@ -38,7 +39,9 @@ import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationConstants;
 import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOperationStatusEnum;
 import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+import jakarta.annotation.PostConstruct;
 
+@Component
 @Interceptor(order = AuthorizationConstants.ORDER_AUTH_INTERCEPTOR + 50)
 public class ResourceManipulationInterceptor {
     @Autowired
@@ -47,13 +50,28 @@ public class ResourceManipulationInterceptor {
     @Autowired
     private ConsentProperties consentProperties;
 
+    @Autowired
+    private ca.uhn.fhir.context.FhirContext fhirContext;
+
     private LoaderWithCache loader;
 
     private boolean isAdminAccess = false;
 
-    public ResourceManipulationInterceptor() {
+    @PostConstruct
+    public void init() {
         loader = new LoaderWithCache(consentProperties);
         loader.setResourceDaoRegistry(resourceDaoRegistry);
+        loader.setFhirContext(fhirContext);
+    }
+
+    /**
+     * Invalidate cache consent list utk satu organisasi. Dipanggil dari
+     * ConsentCacheInvalidationController setiap ada notifikasi perubahan
+     * Consent/Provision dari registry, supaya request berikutnya tidak pakai
+     * cache basi (TTL normalnya 60 menit).
+     */
+    public void invalidateConsentCache(String orgId) {
+        loader.invalidateConsentList(orgId);
     }
 
     @Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_CREATED)

--- a/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/Utils.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/interceptors/Utils.java
@@ -1,0 +1,162 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.AllergyIntolerance;
+import org.hl7.fhir.r4.model.CarePlan;
+import org.hl7.fhir.r4.model.ClinicalImpression;
+import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.DiagnosticReport;
+import org.hl7.fhir.r4.model.Encounter;
+import org.hl7.fhir.r4.model.FamilyMemberHistory;
+import org.hl7.fhir.r4.model.Goal;
+import org.hl7.fhir.r4.model.ImagingStudy;
+import org.hl7.fhir.r4.model.Immunization;
+import org.hl7.fhir.r4.model.Medication;
+import org.hl7.fhir.r4.model.MedicationAdministration;
+import org.hl7.fhir.r4.model.MedicationDispense;
+import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.MedicationStatement;
+import org.hl7.fhir.r4.model.NutritionOrder;
+import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Procedure;
+import org.hl7.fhir.r4.model.QuestionnaireResponse;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.RiskAssessment;
+import org.hl7.fhir.r4.model.ServiceRequest;
+import org.hl7.fhir.r4.model.Specimen;
+import org.hl7.fhir.r4.model.Substance;
+
+public final class Utils {
+    public static String getPatientId(IBaseResource theResource) {
+        if (theResource == null) {
+            return null;
+        }
+
+        Reference patientRef = null;
+
+        if (theResource instanceof Encounter) {
+            patientRef = ((Encounter) theResource).getSubject();
+        } else if (theResource instanceof Condition) {
+            patientRef = ((Condition) theResource).getSubject();
+        } else if (theResource instanceof Procedure) {
+            patientRef = ((Procedure) theResource).getSubject();
+        } else if (theResource instanceof QuestionnaireResponse) {
+            patientRef = ((QuestionnaireResponse) theResource).getSubject();
+        } else if (theResource instanceof Immunization) {
+            patientRef = ((Immunization) theResource).getPatient();
+        } else if (theResource instanceof AllergyIntolerance) {
+            patientRef = ((AllergyIntolerance) theResource).getPatient();
+        } else if (theResource instanceof ClinicalImpression) {
+            patientRef = ((ClinicalImpression) theResource).getSubject();
+        } else if (theResource instanceof CarePlan) {
+            patientRef = ((CarePlan) theResource).getSubject();
+        } else if (theResource instanceof Goal) {
+            patientRef = ((Goal) theResource).getSubject();
+        } else if (theResource instanceof NutritionOrder) {
+            patientRef = ((NutritionOrder) theResource).getPatient();
+        } else if (theResource instanceof ServiceRequest) {
+            patientRef = ((ServiceRequest) theResource).getSubject();
+        } else if (theResource instanceof Specimen) {
+            patientRef = ((Specimen) theResource).getSubject();
+        } else if (theResource instanceof Substance) {
+            // patientRef = ((Substance) theResource).getPatient();
+        } else if (theResource instanceof DiagnosticReport) {
+            patientRef = ((DiagnosticReport) theResource).getSubject();
+        } else if (theResource instanceof Observation) {
+            patientRef = ((Observation) theResource).getSubject();
+        } else if (theResource instanceof Composition) {
+            patientRef = ((Composition) theResource).getSubject();
+        } else if (theResource instanceof Medication) {
+            // patientRef = ((Medication) theResource).getSubject();
+        } else if (theResource instanceof MedicationRequest) {
+            patientRef = ((MedicationRequest) theResource).getSubject();
+        } else if (theResource instanceof MedicationStatement) {
+            patientRef = ((MedicationStatement) theResource).getSubject();
+        } else if (theResource instanceof MedicationAdministration) {
+            patientRef = ((MedicationAdministration) theResource).getSubject();
+        } else if (theResource instanceof MedicationDispense) {
+            patientRef = ((MedicationDispense) theResource).getSubject();
+        } else if (theResource instanceof RiskAssessment) {
+            patientRef = ((RiskAssessment) theResource).getSubject();
+        } else if (theResource instanceof ImagingStudy) {
+            patientRef = ((ImagingStudy) theResource).getSubject();
+        } else if (theResource instanceof FamilyMemberHistory) {
+            patientRef = ((FamilyMemberHistory) theResource).getPatient();
+        }
+
+        if (patientRef != null && patientRef.hasReference()) {
+            String reference = patientRef.getReference();
+            if (reference.startsWith("Patient/")) {
+                return reference.substring("Patient/".length());
+            }
+            return reference;
+        }
+
+        return null;
+    }
+
+    public static String getEncounterId(IBaseResource theResource) {
+        if (theResource == null) {
+            return null;
+        }
+
+        Reference encounterRef = null;
+
+        if (theResource instanceof Condition) {
+            encounterRef = ((Condition) theResource).getEncounter();
+        } else if (theResource instanceof Procedure) {
+            encounterRef = ((Procedure) theResource).getEncounter();
+        } else if (theResource instanceof QuestionnaireResponse) {
+            encounterRef = ((QuestionnaireResponse) theResource).getEncounter();
+        } else if (theResource instanceof Immunization) {
+            encounterRef = ((Immunization) theResource).getEncounter();
+        } else if (theResource instanceof AllergyIntolerance) {
+            encounterRef = ((AllergyIntolerance) theResource).getEncounter();
+        } else if (theResource instanceof ClinicalImpression) {
+            encounterRef = ((ClinicalImpression) theResource).getEncounter();
+        } else if (theResource instanceof CarePlan) {
+            encounterRef = ((CarePlan) theResource).getEncounter();
+        } else if (theResource instanceof NutritionOrder) {
+            encounterRef = ((NutritionOrder) theResource).getEncounter();
+        } else if (theResource instanceof ServiceRequest) {
+            encounterRef = ((ServiceRequest) theResource).getEncounter();
+        } else if (theResource instanceof DiagnosticReport) {
+            encounterRef = ((DiagnosticReport) theResource).getEncounter();
+        } else if (theResource instanceof Observation) {
+            encounterRef = ((Observation) theResource).getEncounter();
+        } else if (theResource instanceof MedicationRequest) {
+            encounterRef = ((MedicationRequest) theResource).getEncounter();
+        } else if (theResource instanceof MedicationStatement) {
+            Reference ref = ((MedicationStatement) theResource).getContext();
+            if (ref != null && ref.hasReference()  && ref.getReference().startsWith("Encounter/")) {
+                encounterRef = ref;
+            }
+        } else if (theResource instanceof MedicationAdministration) {
+            Reference ref = ((MedicationAdministration) theResource).getContext();
+            if (ref != null && ref.hasReference()  && ref.getReference().startsWith("Encounter/")) {
+                encounterRef = ref;
+            }
+        } else if (theResource instanceof MedicationDispense) {
+            Reference ref = ((MedicationDispense) theResource).getContext();
+            if (ref != null && ref.hasReference() && ref.getReference().startsWith("Encounter/")) {
+                encounterRef = ref;
+            }
+        } else if (theResource instanceof RiskAssessment) {
+            encounterRef = ((RiskAssessment) theResource).getEncounter();
+        } else if (theResource instanceof ImagingStudy) {
+            encounterRef = ((ImagingStudy) theResource).getEncounter();
+        }
+
+        if (encounterRef != null && encounterRef.hasReference()) {
+            String reference = encounterRef.getReference();
+            // Extract ID from reference (e.g., "Encounter/123" -> "123")
+            if (reference.startsWith("Encounter/")) {
+                return reference.substring("Encounter/".length());
+            }
+            return reference;
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -395,7 +395,7 @@ hapi:
     # comma-separated package names, will be @ComponentScan'ed by Spring to allow for creating custom Spring beans
 
     # custom-bean-packages:
-    # custom-interceptor-classes:
+    custom-interceptor-classes: ca.uhn.fhir.jpa.starter.interceptors.ConsentEnforcementInterceptor,ca.uhn.fhir.jpa.starter.interceptors.ResourceManipulationInterceptor
     # custom-provider-classes:
     
     # store_meta_source_information: NONE

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -479,3 +479,35 @@ hapi:
         server_address: 'http://localhost:8080/fhir'
         refuse_to_fetch_third_party_urls: false
         fhir_version: R4
+
+  # Policy Enforcement
+  policy:
+    enable: true
+    evaluation_scope: ORGANIZATION # Options: ORGANIZATION, PATIENT, PATIENT-AND-ORGANIZATION
+    administrator:
+      http_header: "X-Administrator-Access"
+      required_name: ADMIN
+    organization:
+      root_manager_id: "9900000000"
+      http_header: "X-Organization-ID"
+      security_system_name: "http://terminology.kemkes.go.id/org-id"
+    consent:
+      registry_url: "http://localhost:7272/api/consent"
+      access:
+        whitelist:
+          - AllergyIntolerance
+          - FamilyMemberHistory
+          - Substance
+    cache:
+      consent:
+        max_size: 800 # jumlah maksimum tersimapn
+        ttl: 60 # time to live dalam menit
+      encounter:
+        max_size: 5000 # jumlah maksimum tersimapn
+        ttl: 5 # time to live dalam menit
+      episode_of_care:
+        max_size: 5000 # jumlah maksimum tersimapn
+        ttl: 5 # time to live dalam menit
+      service_request:
+        max_size: 2000 # jumlah maksimum tersimapn
+        ttl: 10 # time to live dalam menit

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptors/CacheServiceTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptors/CacheServiceTest.java
@@ -1,0 +1,158 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ca.uhn.fhir.jpa.starter.interceptors.CacheService.CacheEnum;
+
+/**
+ * Unit test murni untuk {@link CacheService}, termasuk method
+ * {@link CacheService#invalidate(CacheEnum, Object)} yang ditambahkan untuk
+ * mendukung cache invalidation per-organisasi lewat
+ * {@code /internal/consent-cache/invalidate} (dipanggil oleh consent registry
+ * setiap ada perubahan Consent/Provision).
+ */
+class CacheServiceTest {
+
+    private CacheService cacheService;
+
+    @BeforeEach
+    void setUp() {
+        cacheService = new CacheService();
+    }
+
+    @Test
+    @DisplayName("put lalu getIfPresent mengembalikan value yang sama")
+    void putThenGet_returnsSameValue() {
+        cacheService.put(CacheEnum.CONSENT_LIST, "org-1", "dummy-consent-list-org-1");
+
+        String result = cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "org-1");
+
+        assertEquals("dummy-consent-list-org-1", result);
+    }
+
+    @Test
+    @DisplayName("getIfPresent untuk key yang belum pernah di-put mengembalikan null")
+    void getIfPresent_missingKey_returnsNull() {
+        String result = cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "org-yang-tidak-ada");
+
+        assertNull(result);
+    }
+
+    @Test
+    @DisplayName("get() dengan supplier: cache miss memanggil supplier, cache hit tidak")
+    void get_withSupplier_loadsOnceAndCaches() {
+        int[] callCount = {0};
+
+        String first = cacheService.get(CacheEnum.CONSENT_LIST, "org-2", key -> {
+            callCount[0]++;
+            return "loaded-for-" + key;
+        });
+        String second = cacheService.get(CacheEnum.CONSENT_LIST, "org-2", key -> {
+            callCount[0]++;
+            return "loaded-for-" + key;
+        });
+
+        assertEquals("loaded-for-org-2", first);
+        assertEquals("loaded-for-org-2", second);
+        assertEquals(1, callCount[0], "Supplier cuma boleh dipanggil sekali - kedua kali harus cache hit");
+    }
+
+    // -------------------------------------------------------------------
+    // invalidate(CacheEnum, key) - method baru, dipakai endpoint invalidasi
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("invalidate satu key: key itu hilang, key lain di cache yang sama tetap ada")
+    void invalidate_removesOnlyTargetKey() {
+        cacheService.put(CacheEnum.CONSENT_LIST, "org-a", "consent-list-a");
+        cacheService.put(CacheEnum.CONSENT_LIST, "org-b", "consent-list-b");
+
+        cacheService.invalidate(CacheEnum.CONSENT_LIST, "org-a");
+
+        assertNull(cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "org-a"));
+        assertEquals("consent-list-b", cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "org-b"),
+                "invalidate satu key tidak boleh ikut membuang key lain (bukan invalidateAll)");
+    }
+
+    @Test
+    @DisplayName("invalidate key yang tidak pernah ada tidak melempar exception")
+    void invalidate_nonExistentKey_doesNotThrow() {
+        cacheService.invalidate(CacheEnum.CONSENT_LIST, "org-yang-tidak-pernah-di-put");
+        // tidak ada assertion tambahan - cukup pastikan tidak exception
+    }
+
+    @Test
+    @DisplayName("invalidate di satu tipe cache tidak mempengaruhi tipe cache lain dengan key sama")
+    void invalidate_doesNotCrossCacheTypes() {
+        cacheService.put(CacheEnum.CONSENT_LIST, "123", "consent-value");
+        cacheService.put(CacheEnum.ENCOUNTER, "123", "encounter-value");
+
+        cacheService.invalidate(CacheEnum.CONSENT_LIST, "123");
+
+        assertNull(cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "123"));
+        assertEquals("encounter-value", cacheService.getIfPresent(CacheEnum.ENCOUNTER, "123"),
+                "CacheEnum.ENCOUNTER dengan key yang sama seharusnya tidak ikut ke-invalidate");
+    }
+
+    // -------------------------------------------------------------------
+    // invalidateCaches / invalidateAllCaches (perilaku existing, tetap dijaga)
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("invalidateCaches(CacheEnum) membuang SEMUA entry di cache tipe itu")
+    void invalidateCaches_clearsAllEntriesOfThatType() {
+        cacheService.put(CacheEnum.CONSENT_LIST, "org-a", "a");
+        cacheService.put(CacheEnum.CONSENT_LIST, "org-b", "b");
+
+        cacheService.invalidateCaches(CacheEnum.CONSENT_LIST);
+
+        assertNull(cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "org-a"));
+        assertNull(cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "org-b"));
+    }
+
+    @Test
+    @DisplayName("invalidateAllCaches membuang entry di SEMUA tipe cache")
+    void invalidateAllCaches_clearsEverything() {
+        cacheService.put(CacheEnum.CONSENT_LIST, "org-a", "a");
+        cacheService.put(CacheEnum.ENCOUNTER, "enc-1", "b");
+        cacheService.put(CacheEnum.EPISODE_OF_CARE, "eoc-1", "c");
+        cacheService.put(CacheEnum.SERVICE_REQUEST, "sr-1", "d");
+
+        cacheService.invalidateAllCaches();
+
+        assertNull(cacheService.getIfPresent(CacheEnum.CONSENT_LIST, "org-a"));
+        assertNull(cacheService.getIfPresent(CacheEnum.ENCOUNTER, "enc-1"));
+        assertNull(cacheService.getIfPresent(CacheEnum.EPISODE_OF_CARE, "eoc-1"));
+        assertNull(cacheService.getIfPresent(CacheEnum.SERVICE_REQUEST, "sr-1"));
+    }
+
+    // -------------------------------------------------------------------
+    // CacheEnum.fromResourceType - regresi bug getName() vs getSimpleName()
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("REGRESI: fromResourceType harus dipanggil dengan simple name, bukan FQCN")
+    void fromResourceType_withSimpleName_resolvesCorrectly() {
+        assertEquals(CacheEnum.ENCOUNTER, CacheEnum.fromResourceType("Encounter"));
+        assertEquals(CacheEnum.SERVICE_REQUEST, CacheEnum.fromResourceType("ServiceRequest"));
+        assertEquals(CacheEnum.EPISODE_OF_CARE, CacheEnum.fromResourceType("EpisodeOfCare"));
+    }
+
+    @Test
+    @DisplayName("fromResourceType dengan fully-qualified class name mengembalikan null (bukti kenapa LoaderWithCache wajib pakai getSimpleName())")
+    void fromResourceType_withFullyQualifiedName_returnsNull() {
+        assertNull(CacheEnum.fromResourceType("org.hl7.fhir.r4.model.Encounter"),
+                "Ini bukti nyata bug lama: clz.getName() (FQCN) tidak akan pernah match, harus clz.getSimpleName()");
+    }
+
+    @Test
+    @DisplayName("fromResourceType utk resource type yang tidak dikenal mengembalikan null")
+    void fromResourceType_unknownType_returnsNull() {
+        assertNull(CacheEnum.fromResourceType("Patient"));
+    }
+}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/interceptors/PolicyEvaluatorTest.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/interceptors/PolicyEvaluatorTest.java
@@ -1,0 +1,344 @@
+package ca.uhn.fhir.jpa.starter.interceptors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Condition;
+import org.hl7.fhir.r4.model.Consent;
+import org.hl7.fhir.r4.model.Consent.ConsentProvisionType;
+import org.hl7.fhir.r4.model.Consent.ConsentState;
+import org.hl7.fhir.r4.model.Consent.ProvisionComponent;
+import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.Observation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOperationStatusEnum;
+import ca.uhn.fhir.rest.server.interceptor.consent.ConsentOutcome;
+
+/**
+ * Unit test murni (tanpa Spring context) untuk {@link PolicyEvaluator}.
+ * <p>
+ * Ditulis khusus untuk mencegah regresi dari 2 bug yang pernah ditemukan
+ * di sesi debugging manual (lihat riwayat perubahan {@code PolicyEvaluator.java}):
+ * </p>
+ * <ol>
+ *   <li>Fold logic {@code evaluate()} yang meng-AND-kan seed {@code NULL} di
+ *       iterasi pertama, membuat {@code DENY} tidak pernah ter-propagate.</li>
+ *   <li>Security-label mismatch yang di-negasikan (implicit PERMIT) - perilaku
+ *       yang sengaja, tapi gampang salah diasumsikan sebagai bug kalau tidak
+ *       ada test eksplisit untuk itu.</li>
+ * </ol>
+ */
+class PolicyEvaluatorTest {
+
+    private static final String ORG_ID = "1001";
+    private static final String OTHER_ORG_ID = "9999";
+    private static final String ORG_SECURITY_SYSTEM = "http://terminology.kemkes.go.id/org-id";
+    private static final String ACTION_SYSTEM = "http://terminology.hl7.org/CodeSystem/consentaction";
+    private static final String CLASS_SYSTEM = "http://hl7.org/fhir/resource-types";
+
+    // ---------------------------------------------------------------------
+    // Helper builders
+    // ---------------------------------------------------------------------
+
+    private static Observation observationWithOrgSecurityLabel(String orgId) {
+        Observation obs = new Observation();
+        if (orgId != null) {
+            Meta meta = new Meta();
+            meta.addSecurity(new Coding(ORG_SECURITY_SYSTEM, orgId, null));
+            obs.setMeta(meta);
+        }
+        return obs;
+    }
+
+    private static ProvisionComponent provision(ConsentProvisionType type, String actionCode, String classCode) {
+        ProvisionComponent provision = new ProvisionComponent();
+        provision.setType(type);
+        if (actionCode != null) {
+            provision.addAction(new CodeableConcept().addCoding(new Coding(ACTION_SYSTEM, actionCode, null)));
+        }
+        if (classCode != null) {
+            provision.addClass_(new Coding(CLASS_SYSTEM, classCode, null));
+        }
+        return provision;
+    }
+
+    private static Consent activeConsent(ProvisionComponent provision) {
+        Consent consent = new Consent();
+        consent.setStatus(ConsentState.ACTIVE);
+        consent.setProvision(provision);
+        return consent;
+    }
+
+    private static PolicyEvaluator evaluator(Consent... consents) {
+        return new PolicyEvaluator(PolicyEvaluator.EVALUATION_SCOPE_ORGANIZATION, new ArrayList<>(List.of(consents)));
+    }
+
+    // ---------------------------------------------------------------------
+    // Kasus dasar
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Kasus dasar (tanpa consent / consent kosong)")
+    class BasicCases {
+
+        @Test
+        @DisplayName("Tanpa consent sama sekali -> PROCEED (default fail-open)")
+        void noConsents_shouldProceed() {
+            PolicyEvaluator evaluator = new PolicyEvaluator(PolicyEvaluator.EVALUATION_SCOPE_ORGANIZATION, Collections.emptyList());
+            ConsentOutcome outcome = evaluator.evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+
+        @Test
+        @DisplayName("List consent null -> PROCEED, tidak boleh NullPointerException")
+        void nullConsentList_shouldProceed() {
+            PolicyEvaluator evaluator = new PolicyEvaluator(PolicyEvaluator.EVALUATION_SCOPE_ORGANIZATION, null);
+            ConsentOutcome outcome = evaluator.evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // REGRESI: fold logic evaluate() - bug utama yang ditemukan sesi ini
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Regresi: fold logic evaluate() (bug utama yang pernah ditemukan)")
+    class FoldLogicRegression {
+
+        @Test
+        @DisplayName("Satu consent DENY yang match -> HARUS REJECT (bukan PROCEED)")
+        void singleMatchingDenyConsent_mustReject() {
+            Consent consent = activeConsent(provision(ConsentProvisionType.DENY, "read", "Observation"));
+            PolicyEvaluator evaluator = evaluator(consent);
+
+            ConsentOutcome outcome = evaluator.evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            // Sebelum fix: result di-seed NULL lalu di-AND dengan decision pertama,
+            // provisionOperationAnd(NULL, DENY) = NULL -> selalu PROCEED (bug).
+            assertEquals(ConsentOperationStatusEnum.REJECT, outcome.getStatus(),
+                    "Single DENY consent yang match seharusnya REJECT - kalau test ini gagal, fold logic regresi ke bug lama");
+        }
+
+        @Test
+        @DisplayName("Satu consent PERMIT yang match -> PROCEED")
+        void singleMatchingPermitConsent_shouldProceed() {
+            Consent consent = activeConsent(provision(ConsentProvisionType.PERMIT, "read", "Observation"));
+            PolicyEvaluator evaluator = evaluator(consent);
+
+            ConsentOutcome outcome = evaluator.evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+
+        @Test
+        @DisplayName("DENY + PERMIT (dua consent match) -> DENY selalu menang (safety-first AND)")
+        void denyAndPermitCombined_denyShouldWin() {
+            Consent denyConsent = activeConsent(provision(ConsentProvisionType.DENY, "read", "Observation"));
+            Consent permitConsent = activeConsent(provision(ConsentProvisionType.PERMIT, "read", "Observation"));
+
+            // urutan 1: DENY dulu baru PERMIT
+            ConsentOutcome outcome1 = evaluator(denyConsent, permitConsent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+            assertEquals(ConsentOperationStatusEnum.REJECT, outcome1.getStatus());
+
+            // urutan 2: PERMIT dulu baru DENY - hasil harus sama (operasi AND komutatif)
+            ConsentOutcome outcome2 = evaluator(permitConsent, denyConsent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+            assertEquals(ConsentOperationStatusEnum.REJECT, outcome2.getStatus());
+        }
+
+        @Test
+        @DisplayName("Dua consent PERMIT -> tetap PROCEED")
+        void twoPermitConsents_shouldProceed() {
+            Consent permit1 = activeConsent(provision(ConsentProvisionType.PERMIT, "read", "Observation"));
+            Consent permit2 = activeConsent(provision(ConsentProvisionType.PERMIT, "read", null));
+
+            ConsentOutcome outcome = evaluator(permit1, permit2)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Filter provision: action, class, status
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Filter provision (action, class, status consent)")
+    class ProvisionFiltering {
+
+        @Test
+        @DisplayName("Consent DENY dengan action berbeda (collect) tidak berlaku utk action READ -> PROCEED")
+        void mismatchedAction_shouldNotApply() {
+            Consent consent = activeConsent(provision(ConsentProvisionType.DENY, "collect", "Observation"));
+            ConsentOutcome outcome = evaluator(consent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+
+        @Test
+        @DisplayName("Consent DENY dengan class berbeda (Condition) tidak berlaku utk resource Observation -> PROCEED")
+        void mismatchedResourceClass_shouldNotApply() {
+            Consent consent = activeConsent(provision(ConsentProvisionType.DENY, "read", "Condition"));
+            ConsentOutcome outcome = evaluator(consent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+
+        @Test
+        @DisplayName("Consent DENY tapi class match utk resource yang benar-benar Condition -> REJECT")
+        void matchingResourceClass_shouldApply() {
+            Consent consent = activeConsent(provision(ConsentProvisionType.DENY, "read", "Condition"));
+            Condition condition = new Condition();
+            Meta meta = new Meta();
+            meta.addSecurity(new Coding(ORG_SECURITY_SYSTEM, ORG_ID, null));
+            condition.setMeta(meta);
+
+            ConsentOutcome outcome = evaluator(consent).evaluate(condition, ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.REJECT, outcome.getStatus());
+        }
+
+        @Test
+        @DisplayName("Consent dengan status BUKAN active (mis. draft) -> diabaikan, PROCEED walau provision DENY")
+        void inactiveConsent_shouldBeIgnored() {
+            Consent consent = activeConsent(provision(ConsentProvisionType.DENY, "read", "Observation"));
+            consent.setStatus(ConsentState.DRAFT);
+
+            ConsentOutcome outcome = evaluator(consent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+
+        @Test
+        @DisplayName("Consent tanpa provision sama sekali -> diabaikan, PROCEED")
+        void consentWithoutProvision_shouldBeIgnored() {
+            Consent consent = new Consent();
+            consent.setStatus(ConsentState.ACTIVE);
+            // sengaja tidak setProvision(...)
+
+            ConsentOutcome outcome = evaluator(consent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Security label (organization-level)
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Security label organisasi")
+    class SecurityLabelMatching {
+
+        @Test
+        @DisplayName("Security-label provision MATCH security-label resource -> DENY diterapkan")
+        void matchingSecurityLabel_denyApplies() {
+            ProvisionComponent p = provision(ConsentProvisionType.DENY, "read", "Observation");
+            p.addSecurityLabel(new Coding(ORG_SECURITY_SYSTEM, ORG_ID, null));
+            Consent consent = activeConsent(p);
+
+            ConsentOutcome outcome = evaluator(consent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.REJECT, outcome.getStatus());
+        }
+
+        @Test
+        @DisplayName("Security-label provision TIDAK MATCH security-label resource -> dinegasikan jadi PERMIT (by design)")
+        void mismatchedSecurityLabel_isNegatedToPermit() {
+            ProvisionComponent p = provision(ConsentProvisionType.DENY, "read", "Observation");
+            p.addSecurityLabel(new Coding(ORG_SECURITY_SYSTEM, OTHER_ORG_ID, null));
+            Consent consent = activeConsent(p);
+
+            // Resource-nya security-label ORG_ID, tapi provision target OTHER_ORG_ID -> tidak match
+            ConsentOutcome outcome = evaluator(consent)
+                    .evaluate(observationWithOrgSecurityLabel(ORG_ID), ActionEnum.READ, new ArrayList<>());
+
+            // Ini BUKAN bug - perilaku sengaja (negasi provisionOperationNeg), tapi
+            // gampang disalahpahami. Kalau ini berubah jadi REJECT tanpa disengaja,
+            // artinya ada regresi di checkSecurityLabelProvision().
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus(),
+                    "Security-label mismatch seharusnya di-negasikan jadi PERMIT, bukan tetap DENY atau NULL");
+        }
+
+        @Test
+        @DisplayName("Resource tanpa security-label sama sekali, provision DENY punya security-label -> dinegasikan jadi PERMIT")
+        void resourceWithoutSecurityLabel_isNegatedToPermit() {
+            ProvisionComponent p = provision(ConsentProvisionType.DENY, "read", "Observation");
+            p.addSecurityLabel(new Coding(ORG_SECURITY_SYSTEM, ORG_ID, null));
+            Consent consent = activeConsent(p);
+
+            Observation obsWithoutLabel = new Observation(); // tidak ada Meta.security
+
+            ConsentOutcome outcome = evaluator(consent).evaluate(obsWithoutLabel, ActionEnum.READ, new ArrayList<>());
+
+            assertEquals(ConsentOperationStatusEnum.PROCEED, outcome.getStatus());
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Static operator functions (provisionOperationAnd/Or/Neg)
+    // ---------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Static operator functions")
+    class OperatorFunctions {
+
+        @Test
+        @DisplayName("provisionOperationAnd: PERMIT+PERMIT=PERMIT, DENY menang atas PERMIT, NULL tetap annihilator")
+        void andOperator() {
+            assertEquals(ConsentProvisionType.PERMIT,
+                    PolicyEvaluator.provisionOperationAnd(ConsentProvisionType.PERMIT, ConsentProvisionType.PERMIT));
+            assertEquals(ConsentProvisionType.DENY,
+                    PolicyEvaluator.provisionOperationAnd(ConsentProvisionType.DENY, ConsentProvisionType.PERMIT));
+            assertEquals(ConsentProvisionType.DENY,
+                    PolicyEvaluator.provisionOperationAnd(ConsentProvisionType.PERMIT, ConsentProvisionType.DENY));
+            assertEquals(ConsentProvisionType.DENY,
+                    PolicyEvaluator.provisionOperationAnd(ConsentProvisionType.DENY, ConsentProvisionType.DENY));
+            // NULL adalah annihilator di fungsi level ini (dijaga di level evaluate()
+            // dengan cara skip decision NULL sebelum masuk ke fold, lihat FoldLogicRegression).
+            assertEquals(ConsentProvisionType.NULL,
+                    PolicyEvaluator.provisionOperationAnd(ConsentProvisionType.NULL, ConsentProvisionType.DENY));
+            assertEquals(ConsentProvisionType.NULL,
+                    PolicyEvaluator.provisionOperationAnd(ConsentProvisionType.PERMIT, ConsentProvisionType.NULL));
+        }
+
+        @Test
+        @DisplayName("provisionOperationOr: NULL adalah identity, PERMIT menang atas DENY")
+        void orOperator() {
+            assertEquals(ConsentProvisionType.DENY,
+                    PolicyEvaluator.provisionOperationOr(ConsentProvisionType.NULL, ConsentProvisionType.DENY));
+            assertEquals(ConsentProvisionType.PERMIT,
+                    PolicyEvaluator.provisionOperationOr(ConsentProvisionType.NULL, ConsentProvisionType.PERMIT));
+            assertEquals(ConsentProvisionType.PERMIT,
+                    PolicyEvaluator.provisionOperationOr(ConsentProvisionType.DENY, ConsentProvisionType.PERMIT));
+            assertEquals(ConsentProvisionType.NULL,
+                    PolicyEvaluator.provisionOperationOr(ConsentProvisionType.NULL, ConsentProvisionType.NULL));
+        }
+
+        @Test
+        @DisplayName("provisionOperationNeg: PERMIT<->DENY terbalik, NULL tetap NULL")
+        void negOperator() {
+            assertEquals(ConsentProvisionType.DENY, PolicyEvaluator.provisionOperationNeg(ConsentProvisionType.PERMIT));
+            assertEquals(ConsentProvisionType.PERMIT, PolicyEvaluator.provisionOperationNeg(ConsentProvisionType.DENY));
+            assertEquals(ConsentProvisionType.NULL, PolicyEvaluator.provisionOperationNeg(ConsentProvisionType.NULL));
+        }
+    }
+}


### PR DESCRIPTION
fix(consent): perbaiki interceptor consent yang belum pernah aktif + tambah cache invalidation

Consent interceptor (ConsentEnforcementInterceptor, ResourceManipulationInterceptor)
sudah ditulis tapi tidak pernah berfungsi end-to-end karena beberapa bug independen:

- Interceptor tidak pernah terdaftar ke RestfulServer (wiring hilang)
- ConsentEnforcementService implements interface yang salah
- Parsing response consent registry salah asumsi format (Bundle vs array polos)
- Fold logic PolicyEvaluator.evaluate() membuat DENY tidak pernah ter-propagate
  (bug paling kritis - membuat seluruh consent enforcement jadi no-op)
- loadResourceFromDaoRegistry hardcode ke Encounter.class
- CacheEnum.fromResourceType dipanggil dengan FQCN, bukan simple name
- ResourceManipulationInterceptor.loader tidak pernah di-set FhirContext
- AuditEventLogger reference ke Device yang tidak pernah ada

Fitur baru:
- Endpoint /internal/consent-cache/invalidate untuk invalidasi cache
  consent per-organisasi secara real-time (dipanggil registry via webhook),
  menggantikan ketergantungan pada TTL 60 menit
- Pengecualian api-docs/swagger-ui dari consent check
- Unit test JUnit untuk PolicyEvaluator dan CacheService (regresi bug di atas)

Known limitation (didokumentasikan, sengaja belum diperbaiki):
- EpisodeOfCare.team pakai Reference(Organization) yang tidak sesuai spek
  FHIR R4 (seharusnya Reference(CareTeam)) - perubahan otomatis lewat
  Encounter tidak pernah tersimpan ke database

Testing: 41 skenario Bruno (bruno-consent-testing, repo terpisah), 34 unit
test JUnit baru.