### PR TITLE
Fix MCP search ignoring String query params for Issue#878

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/mcp/RequestBuilder.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mcp/RequestBuilder.java
@@ -39,16 +39,10 @@ public class RequestBuilder {
 		switch (interaction) {
 			case SEARCH -> {
 				method = "GET";
+				Object queryObj = config.get("query");
+				String queryString = (queryObj instanceof String s) ? s : "";
 				req = new MockHttpServletRequest(method, basePath);
-				Map<?, ?> sp = null;
-				if (config.get("query") instanceof Map<?, ?> q) {
-					sp = q;
-				} else if (config.get("searchParams") instanceof Map<?, ?> s) {
-					sp = s;
-				}
-				if (sp != null) {
-					sp.forEach((k, v) -> req.addParameter(k.toString(), v.toString()));
-				}
+				req.setQueryString(queryString);
 			}
 			case READ -> {
 				method = "GET";

--- a/src/main/java/ca/uhn/fhir/jpa/starter/mcp/ToolFactory.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/mcp/ToolFactory.java
@@ -174,7 +174,7 @@ public class ToolFactory {
 			},
 			"query": {
 			"type": "string",
-			"description": "Query string with search params separate by \\",\\". For example: \\"_id=pt-1,name=ivan\\""
+			"description": "Query string with search params separate by \\"&\\". For example: \\"_id=pt-1&name=ivan\\""
 			}
 		},
 		"required": ["resourceType", "query"]

--- a/src/test/java/ca/uhn/fhir/jpa/starter/McpTests.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/McpTests.java
@@ -50,18 +50,33 @@ public class McpTests {
 		assertThat(tools.stream().filter(tool -> tool.name().equals(createToolName)).findFirst().get()).isNotNull();
 
 
-		var createMcpRequest = new McpSchema.CallToolRequest.Builder().arguments(Map.of("operation", "create", "resourceType", "Patient", "resource", """
-			{
-			  "resourceType": "Patient",
-			  "id": "example",
-			  "identifier": [
-			    {
-			      "system": "urn:something",
-			      "value": "uncleScrooge"
-			    }
-			  ]
-			}""")).name(createToolName).build();
-		assertThat(client.callTool(createMcpRequest).isError()).isFalse();
+		var createMcpRequest1 = new McpSchema.CallToolRequest.Builder().arguments(Map.of("operation", "create", "resourceType", "Patient", "resource", """
+       {
+         "resourceType": "Patient",
+         "id": "example",
+         "identifier": [
+           {
+             "system": "urn:something",
+             "value": "uncleScrooge"
+           }
+         ]
+       }""")).name(createToolName).build();
+		assertThat(client.callTool(createMcpRequest1).isError()).isFalse();
+
+
+		var createMcpRequest2 = new McpSchema.CallToolRequest.Builder().arguments(Map.of("operation", "create", "resourceType", "Patient", "resource", """
+       {
+         "resourceType": "Patient",
+         "id": "example2",
+         "identifier": [
+           {
+             "system": "urn:something",
+             "value": "donaldDuck"
+           }
+         ]
+       }""")).name(createToolName).build();
+		assertThat(client.callTool(createMcpRequest2).isError()).isFalse();
+
 
 		var searchMcpRequest = new McpSchema.CallToolRequest.Builder().arguments(Map.of("operation", "search", "resourceType", "Patient", "query", "identifier=urn:something|uncleScrooge")).name(searchToolName).build();
 
@@ -73,7 +88,11 @@ public class McpTests {
 		var embeddedResponseBundle = new Gson().fromJson(content.text(), LinkedHashMap.class).get("response");
 		var responseBundle = fhirContext.newJsonParser().parseResource(Bundle.class, embeddedResponseBundle.toString());
 		var entries = BundleUtil.toListOfEntries(fhirContext, responseBundle);
+
+
 		assertThat(entries.size()).isEqualTo(1);
+		var matchedPatient = (org.hl7.fhir.r4.model.Patient) entries.get(0).getResource();
+		assertThat(matchedPatient.getIdentifierFirstRep().getValue()).isEqualTo("uncleScrooge");
 
 		client.closeGracefully();
 	}

--- a/src/test/java/ca/uhn/fhir/jpa/starter/McpTests.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/McpTests.java
@@ -78,6 +78,18 @@ public class McpTests {
 		assertThat(client.callTool(createMcpRequest2).isError()).isFalse();
 
 
+
+		var unfilteredSearchRequest = new McpSchema.CallToolRequest.Builder().arguments(Map.of("operation", "search", "resourceType", "Patient")).name(searchToolName).build();
+
+		var unfilteredResult = client.callTool(unfilteredSearchRequest);
+		assertThat(unfilteredResult.isError()).isFalse();
+
+		var unfilteredContent = ((McpSchema.TextContent) unfilteredResult.content().get(0));
+		var unfilteredEmbeddedBundle = new Gson().fromJson(unfilteredContent.text(), LinkedHashMap.class).get("response");
+		var unfilteredBundle = fhirContext.newJsonParser().parseResource(Bundle.class, unfilteredEmbeddedBundle.toString());
+		assertThat(BundleUtil.toListOfEntries(fhirContext, unfilteredBundle).size()).isEqualTo(2);
+
+
 		var searchMcpRequest = new McpSchema.CallToolRequest.Builder().arguments(Map.of("operation", "search", "resourceType", "Patient", "query", "identifier=urn:something|uncleScrooge")).name(searchToolName).build();
 
 		var searchResult = client.callTool(searchMcpRequest);


### PR DESCRIPTION
RequestBuilder only handled query/searchParams when they came in as a Map, but the MCP tool actually passes them as a String at runtime, so the instanceof check just silently failed and no filter ever got applied. Changed it too just use the query if its a string. Changed the description in ToolFactory too so the query the AI decides on is already in a standard valid format.