### PR TITLE
Update 8.11 tracking branch for HAPI FHIR 8.11.18-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <micrometer.version>1.16.2</micrometer.version>
         <commons.logging.version>1.3.5</commons.logging.version>
         <spring_boot_version>3.5.9</spring_boot_version>
-        <postgresql.version>42.7.9</postgresql.version>
+        <postgresql.version>42.7.12</postgresql.version>
         <logback_version>1.5.25</logback_version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>8.11.16-SNAPSHOT</version>
+        <version>8.11.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-fhir</artifactId>
-        <version>8.11.17-SNAPSHOT</version>
+        <version>8.11.18-SNAPSHOT</version>
     </parent>
 
     <artifactId>hapi-fhir-jpaserver-starter</artifactId>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -173,8 +173,8 @@ public class StarterJpaConfig {
 	}
 
 	@Bean(name = "myResourceCountsCache")
-	public ResourceCountCache resourceCountsCache(IFhirSystemDao<?, ?> theSystemDao) {
-		return ResourceCountCacheUtil.newResourceCountCache(theSystemDao);
+	public ResourceCountCache resourceCountsCache(DaoRegistry theDaoRegistry) {
+		return ResourceCountCacheUtil.newResourceCountCache(theDaoRegistry);
 	}
 
 	@Primary

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -17,6 +17,7 @@ import ca.uhn.fhir.jpa.api.dao.DaoRegistrationService;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.binary.provider.BinaryAccessProvider;
+import ca.uhn.fhir.jpa.config.SearchConfig;
 import ca.uhn.fhir.jpa.config.util.HapiEntityManagerFactoryUtil;
 import ca.uhn.fhir.jpa.config.util.ResourceCountCacheUtil;
 import ca.uhn.fhir.jpa.dao.FulltextSearchSvcImpl;
@@ -111,7 +112,7 @@ import static ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationInt
 @Configuration
 // allow users to configure custom packages to scan for additional beans
 @ComponentScan(basePackages = {"${hapi.fhir.custom-bean-packages:}"})
-@Import(ThreadPoolFactoryConfig.class)
+@Import({ThreadPoolFactoryConfig.class, SearchConfig.class})
 public class StarterJpaConfig {
 
 	private static final Logger ourLog = LoggerFactory.getLogger(StarterJpaConfig.class);

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -13,6 +13,7 @@ import ca.uhn.fhir.interceptor.model.RequestPartitionId;
 import ca.uhn.fhir.jpa.api.IDaoRegistry;
 import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.config.ThreadPoolFactoryConfig;
+import ca.uhn.fhir.jpa.api.dao.DaoRegistrationService;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.binary.provider.BinaryAccessProvider;
@@ -165,6 +166,16 @@ public class StarterJpaConfig {
 			factory.setPoolMaxTotal(cfg.getPool_max_total());
 			factory.setPoolMaxPerRoute(cfg.getPool_max_per_route());
 		};
+	}
+
+	@Bean
+	public DaoRegistry daoRegistry(FhirContext theFhirContext) {
+		return new DaoRegistry(theFhirContext);
+	}
+
+	@Bean
+	public DaoRegistrationService daoRegistrationService(DaoRegistry theDaoRegistry) {
+		return new DaoRegistrationService(theDaoRegistry);
 	}
 
 	@Bean

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -15,6 +15,7 @@ import ca.uhn.fhir.jpa.api.config.JpaStorageSettings;
 import ca.uhn.fhir.jpa.api.config.ThreadPoolFactoryConfig;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistrationService;
 import ca.uhn.fhir.jpa.api.dao.DaoRegistry;
+import ca.uhn.fhir.jpa.api.dao.IFhirResourceDao;
 import ca.uhn.fhir.jpa.api.dao.IFhirSystemDao;
 import ca.uhn.fhir.jpa.binary.provider.BinaryAccessProvider;
 import ca.uhn.fhir.jpa.config.SearchConfig;
@@ -346,6 +347,7 @@ public class StarterJpaConfig {
 			IFhirSystemDao<?, ?> fhirSystemDao,
 			AppProperties appProperties,
 			DaoRegistry daoRegistry,
+			List<IFhirResourceDao<?>> resourceDaos,
 			Optional<MdmProviderLoader> mdmProviderProvider,
 			IJpaSystemProvider jpaSystemProvider,
 			ResourceProviderFactory resourceProviderFactory,
@@ -374,6 +376,13 @@ public class StarterJpaConfig {
 			Optional<IImplementationGuideOperationProvider> implementationGuideOperationProvider,
 			DiffProvider diffProvider) {
 		RestfulServer fhirServer = new RestfulServer(fhirSystemDao.getContext());
+
+		/*
+		 * Resource providers are selected from the DaoRegistry below.
+		 * Force the generated resource DAOs to initialize and self-register
+		 * before the provider suppliers are evaluated.
+		 */
+		ourLog.info("Initialized {} JPA resource DAO(s)", resourceDaos.size());
 
 		List<String> supportedResourceTypes = appProperties.getSupported_resource_types();
 


### PR DESCRIPTION
## Summary

Updates the HAPI FHIR JPA Server Starter tracking branch for compatibility with HAPI FHIR `8.11.17-SNAPSHOT`.

This change is required by the `DaoRegistry` rework introduced in hapifhir/hapi-fhir#8182. It also provides the compatible starter configuration used to build and run the changes from hapifhir/hapi-fhir#8188.

## Changes

* Updates the HAPI FHIR parent version from `8.11.16-SNAPSHOT` to `8.11.17-SNAPSHOT`.
* Registers the new `DaoRegistry` bean.
* Registers the corresponding `DaoRegistrationService` bean.
* Updates `ResourceCountCache` creation to use `DaoRegistry`.
* Imports the extracted `SearchConfig`.
* Retains `IFhirSystemDao` for the remaining server and conformance-provider integrations that still require it.
* Initializes the generated JPA resource DAOs before evaluating the resource-provider suppliers.
* Includes the latest changes from the starter `master` branch.

## Compatibility changes

### DAO registry services

HAPI FHIR `8.11.17-SNAPSHOT` introduces explicit Spring beans for the new DAO registration flow:

```java
@Bean
public DaoRegistry daoRegistry(FhirContext theFhirContext) {
	return new DaoRegistry(theFhirContext);
}

@Bean
public DaoRegistrationService daoRegistrationService(DaoRegistry theDaoRegistry) {
	return new DaoRegistrationService(theDaoRegistry);
}
```

The starter now provides these beans so that generated resource and system DAOs can register themselves with the shared `DaoRegistry`.

### Resource count cache

HAPI FHIR changed:

```java
ResourceCountCacheUtil.newResourceCountCache(IFhirSystemDao)
```

to:

```java
ResourceCountCacheUtil.newResourceCountCache(DaoRegistry)
```

The starter configuration now supplies the required registry:

```java
@Bean(name = "myResourceCountsCache")
public ResourceCountCache resourceCountsCache(DaoRegistry theDaoRegistry) {
	return ResourceCountCacheUtil.newResourceCountCache(theDaoRegistry);
}
```

### Search configuration

The search-related beans previously provided indirectly through `JpaConfig` were moved into `SearchConfig`.

The starter now imports both configurations:

```java
@Import({ThreadPoolFactoryConfig.class, SearchConfig.class})
```

This provides `ISearchCoordinatorSvc` and the related search task beans required during application startup.

### Resource-provider initialization

Generated resource-provider suppliers determine whether a resource is supported by querying the `DaoRegistry`.

The starter now forces all generated `IFhirResourceDao` beans to initialize before those suppliers are evaluated:

```java
public RestfulServer restfulServer(
		IFhirSystemDao<?, ?> fhirSystemDao,
		AppProperties appProperties,
		DaoRegistry daoRegistry,
		List<IFhirResourceDao<?>> resourceDaos,
		/* ... */) {

	ourLog.info("Initialized {} JPA resource DAO(s)", resourceDaos.size());

	/* ... */
}
```

Without this initialization dependency, only DAOs instantiated by other startup components were registered before the REST providers were created. This caused normal resource endpoints such as `CodeSystem` and `ValueSet` search to be unavailable.

## Verification

The starter was built against the exact head of hapifhir/hapi-fhir#8188 at HAPI FHIR version:

```text
8.11.17-SNAPSHOT
```

The resulting starter WAR was packaged into a Java 21 container image and run against PostgreSQL.

The following runtime checks completed successfully:

* The Spring application context initializes successfully.
* The embedded FHIR server starts successfully.
* `GET /fhir/metadata` returns the R4 capability statement.
* Normal `CodeSystem` and `ValueSet` REST searches are available.

The tested combination was:

```text
hapifhir/hapi-fhir#8188
hapifhir/hapi-fhir-jpaserver-starter#985
```
